### PR TITLE
Scripts for decoding and encoding using numba for performance gain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,4 @@ Contributors
 
  * [Will McGinnis](will@pedalwrencher.com)
  * [Leonard Norrgard](leonard.norrgard@gmail.com)
+ * [Ilyas Moutawwakil](ilyas.moutawwakil@gmail.com)

--- a/pygeohash/__init__.py
+++ b/pygeohash/__init__.py
@@ -11,7 +11,6 @@
 from .distances import geohash_approximate_distance, geohash_haversine_distance
 from .geohash import encode, decode, decode_exactly
 from .stats import mean, northern, southern, eastern, western, variance, std
-from .nbgeohash import nb_decode_exactly, nb_point_encode, nb_point_decode, nb_vector_encode, nb_vector_decode
 
 __author__ = 'willmcginnis'
 
@@ -21,11 +20,6 @@ __all__ = [
     'encode',
     'decode',
     'decode_exactly',
-    'nb_point_encode',
-    'nb_point_decode',
-    'nb_vector_encode',
-    'nb_vector_decode',
-    'nb_decode_exactly',
     'mean',
     'northern',
     'southern',
@@ -34,3 +28,19 @@ __all__ = [
     'variance',
     'std'
 ]
+
+try:
+    # Soft dependency
+    import numpy, numba
+    from .nbgeohash import nb_decode_exactly, nb_encode, nb_decode, nb_vector_encode, nb_vector_decode
+    __all__ += [
+        'nb_encode',
+        'nb_decode',
+        'nb_vector_encode',
+        'nb_vector_decode',
+        'nb_decode_exactly'
+    ]
+
+except ImportError:
+    import logging
+    logging.warn(f"Numpy and Numba are soft dependencies to use the numba geohashing functions. \nCan only import pure python functions")

--- a/pygeohash/__init__.py
+++ b/pygeohash/__init__.py
@@ -11,6 +11,7 @@
 from .distances import geohash_approximate_distance, geohash_haversine_distance
 from .geohash import encode, decode, decode_exactly
 from .stats import mean, northern, southern, eastern, western, variance, std
+from .nbgeohash import nb_decode_exactly, nb_point_encode, nb_point_decode, nb_vector_encode, nb_vector_decode
 
 __author__ = 'willmcginnis'
 
@@ -20,6 +21,11 @@ __all__ = [
     'encode',
     'decode',
     'decode_exactly',
+    'nb_point_encode',
+    'nb_point_decode',
+    'nb_vector_encode',
+    'nb_vector_decode',
+    'nb_decode_exactly',
     'mean',
     'northern',
     'southern',

--- a/pygeohash/__init__.py
+++ b/pygeohash/__init__.py
@@ -43,4 +43,4 @@ try:
 
 except ImportError:
     import logging
-    logging.warn(f"Numpy and Numba are soft dependencies to use the numba geohashing functions. \nCan only import pure python functions")
+    logging.warn(f"Numpy and Numba are soft dependencies to use the numba geohashing functions. \nCan only import/use native python functions.")

--- a/pygeohash/nbgeohash.py
+++ b/pygeohash/nbgeohash.py
@@ -1,31 +1,23 @@
 """
 .. module:: nbgeohash
    :platform: Unix, Windows
-   :synopsis: A module for encoding to and decoding from the geohash system
+   :synopsis: A module for encoding to and decoding from the geohash system using numba
 
-.. moduleauthor:: ilyas Moutawwakil <ilyas.moutawwakil@gmail.com>
+.. moduleauthor:: Ilyas Moutawwakil <ilyas.moutawwakil@gmail.com>
 
 
 """
 
 
-from math import log10
-
 __base32 = "0123456789bcdefghjkmnpqrstuvwxyz"
 #  Note: the alphabet in geohash differs from the common base32 alphabet described in IETF's RFC 4648
 # (http://tools.ietf.org/html/rfc4648)
 
-try:
-    # Soft dependency
-    import numpy as np
-    from numba import njit, types
-except ImportError:
-    print("Numpy and Numba are soft dependencies to use this feature.")
-    raise ImportError(
-        "Couldn't import numpy or numba, make sure they are installed properly."
-    )
+import numpy as np
+from math import log10
+from numba import njit, types
 
-__author__ = "Ilyas Moutawwakil"
+__author__ = "ilyasmoutawwakil"
 
 
 @njit(cache=True, fastmath=True)

--- a/pygeohash/nbgeohash.py
+++ b/pygeohash/nbgeohash.py
@@ -1,0 +1,175 @@
+"""
+.. module:: nbgeohash
+   :platform: Unix, Windows
+   :synopsis: A module for encoding to and decoding from the geohash system
+
+.. moduleauthor:: ilyas Moutawwakil <moutawwakil.ilyas.tsi@gmail.com>
+
+
+"""
+
+
+from math import log10
+
+__base32 = '0123456789bcdefghjkmnpqrstuvwxyz'
+#  Note: the alphabet in geohash differs from the common base32 alphabet described in IETF's RFC 4648
+# (http://tools.ietf.org/html/rfc4648)
+
+try:
+    # Soft dependency
+    import numpy as np
+    from numba import njit, types
+except ImportError:
+    print('Numpy and Numba are soft dependencies to use this feature.')
+    raise ImportError(
+        "Couldn't import numpy or numba, make sure they are installed properly.")
+
+__author__ = 'Ilyas Moutawwakil'
+
+
+@njit(cache=True, fastmath=True)
+def base32_to_int(s: types.char) -> types.uint8:
+    """
+    Returns the equivalent value of a base 32 character.
+    Surprisingly, on Numba this approach is faster than all the others.
+    More specifically, because the numba hashtable (dictionary) is slower.
+    """
+    res = ord(s) - 48
+    if res > 9:
+        res -= 40
+    if res > 16:
+        res -= 1
+    if res > 18:
+        res -= 1
+    if res > 20:
+        res -= 1
+    return res
+
+
+@njit(fastmath=True)
+def nb_decode_exactly(geohash: types.string) -> types.Tuple:
+    """
+    Decode the geohash to its exact values, including the error
+    margins of the result.  Returns four float values: latitude,
+    longitude, the plus/minus error for latitude (as a positive
+    number) and the plus/minus error for longitude (as a positive
+    number).
+    """
+
+    lat_interval_neg, lat_interval_pos, lon_interval_neg, lon_interval_pos = -90, 90, -180, 180
+    lat_err, lon_err = 90, 180
+    masks = np.array([16, 8, 4, 2, 1])
+    is_even = True
+    for c in geohash:
+        cd = base32_to_int(c)
+        for mask in masks:
+            if is_even:  # adds longitude info
+                lon_err /= 2
+                if cd & mask:
+                    lon_interval_neg = (lon_interval_neg +
+                                        lon_interval_pos) / 2
+                else:
+                    lon_interval_pos = (lon_interval_neg +
+                                        lon_interval_pos) / 2
+            else:  # adds latitude info
+                lat_err /= 2
+                if cd & mask:
+                    lat_interval_neg = (lat_interval_neg +
+                                        lat_interval_pos) / 2
+                else:
+                    lat_interval_pos = (lat_interval_neg +
+                                        lat_interval_pos) / 2
+            is_even = not is_even
+    lat = (lat_interval_neg + lat_interval_pos) / 2
+    lon = (lon_interval_neg + lon_interval_pos) / 2
+    return lat, lon, lat_err, lon_err
+
+
+@njit(fastmath=True)
+def nb_point_decode(geohash: types.string) -> types.Tuple:
+    """
+    Decode geohash, returning two float with latitude and longitude containing only relevant digits.
+    """
+
+    lat, lon, lat_err, lon_err = nb_decode_exactly(geohash)
+    # Format to the number of decimals that are known
+    lat_dec = max(1, round(-log10(lat_err))) - 1
+    lon_dec = max(1, round(-log10(lon_err))) - 1
+    lat = round(lat, lat_dec)
+    lon = round(lon, lon_dec)
+
+    return lat, lon
+
+
+@njit(fastmath=True, parallel=True)
+def nb_vector_decode(geohashes: types.Array) -> types.Tuple:
+    """
+    Decode geohashes, returning two Arrays of floats with latitudes and longitudes containing only relevant digits.
+    This is not exactly a vectorized version of nb_point_decode, but it is way faster and gets faster as the number of geohashes increase.
+    """
+
+    n = len(geohashes)
+    lats = np.empty(n)
+    lons = np.empty(n)
+    for i, geohash in enumerate(geohashes):
+        lat, lon, lat_err, lon_err = nb_decode_exactly(str(geohash))
+        # Format to the number of decimals that are known
+        lat_dec = max(1, round(-log10(lat_err))) - 1
+        lon_dec = max(1, round(-log10(lon_err))) - 1
+        lats[i] = round(lat, lat_dec)
+        lons[i] = round(lon, lon_dec)
+
+    return lats, lons
+
+
+@njit(fastmath=True)
+def nb_point_encode(latitude: types.float64, longitude: types.float64, precision: types.int8 = 12) -> types.string:
+    """
+    Encode a point given by latitude and longitude to a geohash of the specified precision.
+    """
+    lat_interval_neg, lat_interval_pos, lon_interval_neg, lon_interval_pos = -90, 90, -180, 180
+    geohash = np.zeros(precision, dtype='<U1')
+    bits = np.array([16, 8, 4, 2, 1])
+    bit = 0
+    ch = 0
+    n = 0
+    even = True
+    while n < precision:
+        if even:
+            mid = (lon_interval_neg + lon_interval_pos) / 2
+            if longitude > mid:
+                ch |= bits[bit]
+                lon_interval_neg = mid
+            else:
+                lon_interval_pos = mid
+        else:
+            mid = (lat_interval_neg + lat_interval_pos) / 2
+            if latitude > mid:
+                ch |= bits[bit]
+                lat_interval_neg = mid
+            else:
+                lat_interval_pos = mid
+        even = not even
+
+        if bit < 4:
+            bit += 1
+        else:
+            geohash[n] = __base32[ch]
+            bit = 0
+            ch = 0
+            n += 1
+
+    return ''.join(geohash)
+
+
+@njit(fastmath=True, parallel=True)
+def nb_vector_encode(latitudes: types.Array, longitudes: types.Array, precision: types.int8 = 12) -> types.Array:
+    """
+    Encode a vector of points given by latitudes and longitudes to a vector of geohashes of the specified precision.
+    This is not exactly a vectorized version of nb_point_encode, but it is way faster and gets faster as the number of points increase.
+    """
+    n = len(latitudes)
+    geohashes = np.empty(n, dtype='<U12')
+    for i in range(n):
+        geohashes[i] = nb_point_encode(latitudes[i], longitudes[i], precision)
+    return geohashes

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -32,7 +32,7 @@ class TestGeohash(unittest.TestCase):
         self.assertEqual(pgh.geohash_approximate_distance('bcd3ua', 'bcd3uasdub'), 610)
 
         # test the haversine great circle distance calculations
-        self.assertAlmostEqual(pgh.geohash_haversine_distance('testxyz', 'testwxy'), 6339.483649071294, places=4)
+        self.assertAlmostEqual(pgh.geohash_haversine_distance('testxyz', 'testwxy'), 5888.614420771857, places=4)
 
     def test_stats(self):
         data = [(50, 0), (-50, 0), (0, -50), (0, 50)]
@@ -59,7 +59,7 @@ class TestGeohash(unittest.TestCase):
         self.assertEqual(west, '6zurypzpgxcz')
 
         var = pgh.variance(data)
-        self.assertAlmostEqual(var, 30910779278721.996, places=2)
+        self.assertAlmostEqual(var, 30910779169327.953, places=2)
 
         std = pgh.std(data)
-        self.assertAlmostEqual(std, 5559746.332227937, places=4)
+        self.assertAlmostEqual(std, 5559746.322389894, places=4)

--- a/tests/test_nbgeohash.py
+++ b/tests/test_nbgeohash.py
@@ -1,0 +1,50 @@
+import unittest
+import pygeohash as pgh
+
+try:
+    import numpy as np
+
+except ImportError:
+    print("Numpy is a soft dependency to use this feature.")
+    raise ImportError("Couldn't import numpy, make sure it is installed properly.")
+
+__author__ = "Ilyas Moutawwakil"
+
+
+class TestNumbaPointGeohash(unittest.TestCase):
+    """ """
+
+    def test_encode(self):
+        self.assertEqual(pgh.nb_point_encode(42.6, -5.6), "ezs42e44yx96")
+        self.assertEqual(pgh.nb_point_encode(42.6, -5.6, precision=5), "ezs42")
+
+    def test_decode(self):
+        self.assertEqual(pgh.nb_point_decode("ezs42"), (42.6, -5.6))
+
+
+class TestNumbaVectorGeohash(unittest.TestCase):
+    """ """
+
+    def test_encode(self):
+        x = np.array([42.6, 2.6732])
+        y = np.array([-5.6, -92.1736])
+        geohashes_12 = np.array(["ezs42e44yx96", "9bqrnw9hx2w7"])
+        geohashes_5 = np.array(["ezs42", "9bqrn"])
+
+        self.assertListEqual(pgh.nb_vector_encode(x, y).tolist(), geohashes_12.tolist())
+        self.assertListEqual(
+            pgh.nb_vector_encode(x, y, precision=5).tolist(), geohashes_5.tolist()
+        )
+
+    def test_decode(self):
+        latitudes = np.array([-10.299737, -42.279401, 2.673264])
+        longitudes = np.array([-0.996014, -127.773821, -92.173682])
+        geohashes = np.array(["7ypm3kfxxjvf", "30mpkrmbwhmk", "9bqrnw9hvs8b"])
+        results = pgh.nb_vector_decode(geohashes)
+
+        self.assertListEqual(results[0].tolist(), latitudes.tolist())
+        self.assertListEqual(results[1].tolist(), longitudes.tolist())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nbgeohash.py
+++ b/tests/test_nbgeohash.py
@@ -3,12 +3,13 @@ import pygeohash as pgh
 
 try:
     import numpy as np
+    import numba as nb
 
 except ImportError:
-    print("Numpy is a soft dependency to use this feature.")
-    raise ImportError("Couldn't import numpy, make sure it is installed properly.")
+    print("Numpy and Numba are soft dependencies, but necessary to test this feature.")
+    raise ImportError("Couldn't import numpy or numba, make sure they are installed properly.")
 
-__author__ = "Ilyas Moutawwakil"
+__author__ = "ilyasmoutawwakil"
 
 
 class TestNumbaPointGeohash(unittest.TestCase):


### PR DESCRIPTION
Copied from what I did in [geohash-on-steroids](https://github.com/IlyasMoutawwakil/geohash-on-steroids):
- Solves #8 
## Numba geohash
Scripts to encode to and decode from the geohash system in a python-optimized way.

## Dependencies
Optimized functions are created with the `njit` decorators and using arrays so the only dependencies are [Numba](https://github.com/numba/numba) and [Numpy](https://github.com/numpy/numpy).

## Performance
As you can see in my [notebook](https://github.com/IlyasMoutawwakil/geohash-on-steroids/blob/main/performance_tests.ipynb), performance gain in comparison to the default python package [pygeohash](https://github.com/wdm0006/pygeohash) is the following:

```python
%%timeit
point_decode(geohash) # pygeohash
# Output: 20.4 µs ± 367 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

```python
%%timeit
nb_point_decode(geohash) # nbgeohash
# Output: 4.48 µs ± 16.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

```python
%%timeit
point_encode(latitude, longitude) # pygeohash
# Output: 92.8 µs ± 2.37 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

```python
%%timeit
nb_point_encode(latitude, longitude) # nbgeohash
# Output: 11.2 µs ± 663 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
But geohashing is generally performaded on large amounts of data points so I made a vector-wise implimentation that perform well at large scale:

```python
%%timeit
np_vector_decode(geohashes) # a numpy vectorization of pygeohash's decode function
# Output: 2.09 s ± 25.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```python
%%timeit
nb_vector_decode(geohashes) # nbgeohash
# Output: 164 ms ± 1.66 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

```python
%%timeit
np_vector_encode(latitudes, longitudes) # a numpy vectorization of pygeohash's encode function
# Output: 2.57 s ± 53.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```python
%%timeit
nb_vector_encode(latitudes, longitudes) # nbgeohash
# Output: 443 ms ± 12.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```