### PR TITLE
add neighboring functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ To use pygeohash:
     
     pgh.geohash_approximate_distance(geohash_1='bcd3u', geohash_2='bc83n')
     # >>> 625441
+	
+    pgh.get_adjacent(geohash='kd3ybyu', direction='right')
+    # >>> kd3ybyv
 
 Installation
 ============

--- a/pygeohash/__init__.py
+++ b/pygeohash/__init__.py
@@ -11,6 +11,7 @@
 from .distances import geohash_approximate_distance, geohash_haversine_distance
 from .geohash import encode, decode, decode_exactly
 from .stats import mean, northern, southern, eastern, western, variance, std
+from .neighbor import get_adjacent
 
 __author__ = 'willmcginnis'
 
@@ -26,5 +27,6 @@ __all__ = [
     'eastern',
     'western',
     'variance',
-    'std'
+    'std',
+    'get_adjacent',
 ]

--- a/pygeohash/neighbor.py
+++ b/pygeohash/neighbor.py
@@ -1,0 +1,71 @@
+"""
+.. module:: neighbor
+   :platform: Unix, Windows
+   :synopsis: A module for calculating adjacent geohash
+
+.. moduleauthor:: Nicolas Mine
+
+
+"""
+
+from .geohash import __base32
+
+# Configuration  -- from https://github.com/davetroy/geohash-js/blob/master/geohash.js
+NEIGHBORS = { 
+    "right"  : { 
+        "even" : "bc01fg45238967deuvhjyznpkmstqrwx",
+        "odd"  : "p0r21436x8zb9dcf5h7kjnmqesgutwvy"   # = top-even
+    },
+	"left"   : { 
+        "even" : "238967debc01fg45kmstqrwxuvhjyznp",
+        "odd"  : "14365h7k9dcfesgujnmqp0r2twvyx8zb"   # = bottom-even
+    },
+	"top"    : { 
+        "even" : "p0r21436x8zb9dcf5h7kjnmqesgutwvy",
+        "odd"  : "bc01fg45238967deuvhjyznpkmstqrwx"  # = right-even
+    },
+	"bottom" : { 
+        "even" : "14365h7k9dcfesgujnmqp0r2twvyx8zb",
+        "odd"  : "238967debc01fg45kmstqrwxuvhjyznp"  # = left-even
+    }
+}
+
+# Used change of parent tile
+BORDERS   = { 
+    "right"  : { 
+        "even" : "bcfguvyz",
+        "odd"  : "prxz"  # top-even
+    },
+	"left"   : { 
+        "even" : "0145hjnp",
+        "odd"  : "028b"  # bottom-even
+    },
+	"top"    : { 
+        "even" : "prxz",
+        "odd"  : "bcfguvyz"  # right-even
+    },
+	"bottom" : { 
+        "even" : "028b",
+        "odd"  : "0145hjnp"  # left-even
+    } 
+}
+
+
+def get_adjacent(geohash: str, direction :str) -> str:
+    """
+    return the adjacent hash of a given geohash.
+    Direction can be right, left, top, bottom
+    """
+    if (len(geohash) == 0):
+        raise ValueError("The geohash length cannot be 0. Possible when close to poles")
+    srcHash = geohash.lower()
+    lastChr = srcHash[-1]
+    base = srcHash[:-1]
+
+    splitDirection = ['even', 'odd'][len(srcHash)%2]
+
+    if lastChr in BORDERS[direction][splitDirection]:
+        base = get_adjacent(base, direction)
+
+
+    return base + __base32[NEIGHBORS[direction][splitDirection].index(lastChr)]

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -1,0 +1,48 @@
+import unittest
+import pygeohash as pgh
+
+
+__author__ = 'willmcginnis'
+
+
+class TestGeohash(unittest.TestCase):
+    """
+    Thest neightboring - test case created using https://www.movable-type.co.uk/scripts/geohash.html
+    """
+    def test_north_hemisphere_simple_odd(self):
+        self.assertEqual(pgh.get_adjacent("gbsuv", "right"), 'gbsuy')
+        self.assertEqual(pgh.get_adjacent("gbsuv", "left"), 'gbsuu')
+        self.assertEqual(pgh.get_adjacent("gbsuv", "top"), 'gbsvj')
+        self.assertEqual(pgh.get_adjacent("gbsuv", "bottom"), 'gbsut')
+
+    def test_north_hemisphere_border_even(self):
+        self.assertEqual(pgh.get_adjacent("u00000", "right"), 'u00002')
+        self.assertEqual(pgh.get_adjacent("u00000", "left"), 'gbpbpb')
+        self.assertEqual(pgh.get_adjacent("u00000", "top"), 'u00001') 
+        self.assertEqual(pgh.get_adjacent("u00000", "bottom"), 'spbpbp')
+
+    def test_south_hemisphere_simple_odd(self):
+        self.assertEqual(pgh.get_adjacent("kd3ybyu", "right"), 'kd3ybyv')
+        self.assertEqual(pgh.get_adjacent("kd3ybyu", "left"), 'kd3ybyg')
+        self.assertEqual(pgh.get_adjacent("kd3ybyu", "top"), 'kd3ybzh')
+        self.assertEqual(pgh.get_adjacent("kd3ybyu", "bottom"), 'kd3ybys')
+
+    def test_south_hemisphere_border_even(self):
+        self.assertEqual(pgh.get_adjacent("k0000000", "right"), 'k0000002')
+        self.assertEqual(pgh.get_adjacent("k0000000", "left"), '7bpbpbpb')
+        self.assertEqual(pgh.get_adjacent("k0000000", "top"), 'k0000001') 
+        self.assertEqual(pgh.get_adjacent("k0000000", "bottom"), 'hpbpbpbp')
+
+    def test_north_pole_even(self):
+        self.assertEqual(pgh.get_adjacent("gzzzzz", "right"), 'upbpbp')
+        self.assertEqual(pgh.get_adjacent("gzzzzz", "left"), 'gzzzzx')
+        self.assertEqual(pgh.get_adjacent("gzzzzz", "bottom"), 'gzzzzy')
+        with self.assertRaises(ValueError):
+            pgh.get_adjacent("gzzzzz", "top")
+
+    def test_south_pole_odd(self):
+        self.assertEqual(pgh.get_adjacent("5bpbpbh", "right"), '5bpbpbj')
+        self.assertEqual(pgh.get_adjacent("5bpbpbh", "left"), '5bpbpb5')
+        self.assertEqual(pgh.get_adjacent("5bpbpbh", "top"), '5bpbpbk') 
+        with self.assertRaises(ValueError):
+            pgh.get_adjacent("5bpbpbh", "bottom")


### PR DESCRIPTION
I have added a functionality to get adjacents geohashes of a given geohash. It has been tested in a seperated test script using https://www.movable-type.co.uk/scripts/geohash.html. 

The only difference with the website is for the top tile of north pole (or bottom tile of south pole) that are undefined and raise a ValueError.