### PR TITLE
Add an encode_strictly function that fixes the handling of the 0 geographical location

### DIFF
--- a/pygeohash/__init__.py
+++ b/pygeohash/__init__.py
@@ -9,7 +9,7 @@
 """
 
 from .distances import geohash_approximate_distance, geohash_haversine_distance
-from .geohash import encode, decode, decode_exactly
+from .geohash import encode, decode, decode_exactly, encode_strictly
 from .stats import mean, northern, southern, eastern, western, variance, std
 from .neighbor import get_adjacent
 
@@ -19,6 +19,7 @@ __all__ = [
     'geohash_approximate_distance',
     'geohash_haversine_distance',
     'encode',
+    'encode_strictly',
     'decode',
     'decode_exactly',
     'mean',

--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -115,4 +115,40 @@ def encode(latitude, longitude, precision=12):
     return ''.join(geohash)
 
 
-
+def encode_strictly(latitude, longitude, precision=12):
+    """
+    Encode a position given in float arguments latitude, longitude to
+    a geohash which will have the character count precision.
+    When compared to mid, mid should be included.
+    Provide a separate method for backward compatibility.
+    """
+    lat_interval = (-90.0, 90.0)
+    lon_interval = (-180.0, 180.0)
+    geohash = []
+    bits = [16, 8, 4, 2, 1]
+    bit = 0
+    ch = 0
+    even = True
+    while len(geohash) < precision:
+        if even:
+            mid = (lon_interval[0] + lon_interval[1]) / 2
+            if longitude >= mid:
+                ch |= bits[bit]
+                lon_interval = (mid, lon_interval[1])
+            else:
+                lon_interval = (lon_interval[0], mid)
+        else:
+            mid = (lat_interval[0] + lat_interval[1]) / 2
+            if latitude >= mid:
+                ch |= bits[bit]
+                lat_interval = (mid, lat_interval[1])
+            else:
+                lat_interval = (lat_interval[0], mid)
+        even = not even
+        if bit < 4:
+            bit += 1
+        else:
+            geohash += __base32[ch]
+            bit = 0
+            ch = 0
+    return ''.join(geohash)

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -12,6 +12,11 @@ class TestGeohash(unittest.TestCase):
         self.assertEqual(pgh.encode(42.6, -5.6), 'ezs42e44yx96')
         self.assertEqual(pgh.encode(42.6, -5.6, precision=5), 'ezs42')
 
+    def test_encode_strictly(self):
+        self.assertEqual(pgh.encode(0.0, -5.6, precision=5), '7zupb')
+        self.assertEqual(pgh.encode_strictly(0.0, -5.6, precision=5), 'ebh00')
+
+
     def test_decode(self):
         self.assertEqual(pgh.decode('ezs42'), (42.6, -5.6))
 


### PR DESCRIPTION
Issue: https://github.com/wdm0006/pygeohash/issues/16

