### PR TITLE
Update metadata to avoid dashes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 
 [metadata]
-description-file=README.md
+description_file=README.md


### PR DESCRIPTION
This change is to avoid the "SetuptoolsDeprecationWarning: Invalid dash-separated options" when installing this package via setuptools.  Resolves #23 