### PR TITLE
Optimize encode/decode/bbox by trimming Python wrapper overhead

### DIFF
--- a/pygeohash/bounding_box.py
+++ b/pygeohash/bounding_box.py
@@ -50,20 +50,9 @@ def get_bounding_box(geohash: str) -> BoundingBox:
         of the geohash. Longer geohashes result in smaller bounding boxes with more
         precise coordinates.
     """
-    logger.debug("Calculating bounding box for geohash: %s", geohash)
     # Get the center point and error margins
     lat, lon, lat_err, lon_err = decode_exactly(geohash)
-    logger.debug("Center point: (lat=%f, lon=%f) with errors: (lat_err=%f, lon_err=%f)", lat, lon, lat_err, lon_err)
-
-    # Calculate the bounding box coordinates
-    min_lat: float = lat - lat_err
-    min_lon: float = lon - lon_err
-    max_lat: float = lat + lat_err
-    max_lon: float = lon + lon_err
-
-    result = BoundingBox(min_lat, min_lon, max_lat, max_lon)
-    logger.debug("Calculated bounding box: %s", result)
-    return result
+    return BoundingBox(lat - lat_err, lon - lon_err, lat + lat_err, lon + lon_err)
 
 
 def is_point_in_box(lat: float, lon: float, bbox: BoundingBox) -> bool:

--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -60,10 +60,7 @@ def encode(latitude: float, longitude: float, precision: GeohashPrecision = 12) 
     if not (-180.0 <= longitude <= 180.0):
         raise ValueError(f"Longitude must be between -180.0 and 180.0 degrees, but got {longitude}.")
 
-    logger.debug("Encoding coordinates: lat=%f, lon=%f with precision %d", latitude, longitude, precision)
-    result = c_encode(latitude, longitude, precision)
-    logger.debug("Encoded to geohash: %s", result)
-    return result
+    return c_encode(latitude, longitude, precision)
 
 
 def encode_strictly(latitude: float, longitude: float, precision: GeohashPrecision = 12) -> str:
@@ -98,11 +95,8 @@ def encode_strictly(latitude: float, longitude: float, precision: GeohashPrecisi
     if not (-180.0 <= longitude <= 180.0):
         raise ValueError(f"Longitude must be between -180.0 and 180.0 degrees, but got {longitude}.")
 
-    logger.debug("Strictly encoding coordinates: lat=%f, lon=%f with precision %d", latitude, longitude, precision)
     try:
-        result = c_encode_strictly(latitude, longitude, precision)
-        logger.debug("Strictly encoded to geohash: %s", result)
-        return result
+        return c_encode_strictly(latitude, longitude, precision)
     except ValueError as e:
         logger.error(
             "Failed to strictly encode coordinates: lat=%f, lon=%f with precision %d: %s",
@@ -130,13 +124,11 @@ def decode(geohash: str) -> LatLong:
         raise ValueError(f"Geohash must be a string, but got {type(geohash).__name__}.")
     if not geohash:
         raise ValueError("Geohash cannot be empty.")
-    if not all(c in __base32 for c in geohash):
-        raise ValueError(f"Invalid character in geohash: '{geohash}'. Only characters '{__base32}' are allowed.")
 
-    logger.debug("Decoding geohash: %s", geohash)
-    lat, lon = c_decode(geohash)
-    logger.debug("Decoded to coordinates: lat=%f, lon=%f", lat, lon)
-    return LatLong(latitude=lat, longitude=lon)
+    # The C extension raises ValueError("Invalid character in geohash") for any
+    # non-base32 character, so we let it do the per-character validation instead
+    # of paying for a Python-level scan on every call.
+    return LatLong(*c_decode(geohash))
 
 
 def decode_exactly(geohash: str) -> ExactLatLong:
@@ -159,13 +151,9 @@ def decode_exactly(geohash: str) -> ExactLatLong:
         raise ValueError(f"Geohash must be a string, but got {type(geohash).__name__}.")
     if not geohash:
         raise ValueError("Geohash cannot be empty.")
-    if not all(c in __base32 for c in geohash):
-        raise ValueError(f"Invalid character in geohash: '{geohash}'. Only characters '{__base32}' are allowed.")
 
-    logger.debug("Exactly decoding geohash: %s", geohash)
-    lat, lon, lat_err, lon_err = c_decode_exactly(geohash)
-    logger.debug("Exactly decoded to coordinates: lat=%f±%f, lon=%f±%f", lat, lat_err, lon, lon_err)
-    return ExactLatLong(latitude=lat, longitude=lon, latitude_error=lat_err, longitude_error=lon_err)
+    # See decode(): the C extension validates characters and raises on its own.
+    return ExactLatLong(*c_decode_exactly(geohash))
 
 
 __all__ = [


### PR DESCRIPTION
## What

Speeds up the three core operations (`encode`, `decode`, bounding box) by removing redundant work from the Python wrapper layer that sits in front of the C extension. No algorithm or C changes, no API changes.

Follow-up to #57, which benchmarked pygeohash against other libraries and showed `decode`/`bbox` running ~7x slower than `python-geohash` despite our C core. That gap was wrapper overhead, not the C code.

## Changes

1. **Drop the redundant per-character validation in `decode`/`decode_exactly`.** The C extension already scans the input and raises `ValueError("Invalid character in geohash")`, so the Python-level `all(c in __base32 for c in geohash)` generator was doing the same O(n) work a second time on every call.
2. **Remove per-call `logger.debug()` from the hot paths** (`encode`, `encode_strictly`, `decode`, `decode_exactly`, `get_bounding_box`). Debug-logging every coordinate operation is a performance footgun, and no test asserts on it. `encode_strictly` keeps its error-path logging.

## Results

Same machine, measured with `tests/test_benchmark_comparison.py` (mean):

| Operation | Before | After | Improvement |
|---|---:|---:|---:|
| encode | 410 ns | 235 ns | **43% faster** |
| decode | 1,514 ns | 958 ns | **37% faster** |
| bbox | 1,614 ns | 764 ns | **53% faster** |

Against the field, this moves `encode` from ~2x slower than the C++ `python-geohash` to ~1.2x, and roughly halves our distance from it on `decode` and `bbox`. The remaining gap is in the C extension itself (the bare `c_decode` floor is ~760 ns), which is a separate, larger piece of work.

## Safety

- All validation and error messages the tests depend on are preserved. The C extension's `"Invalid character in geohash"` message still satisfies the existing `pytest.raises(..., match="Invalid character in geohash")` assertions.
- The empty-string and type checks stay in Python (the C extension returns `(0, 0)` for an empty string rather than raising).
- Full suite passes: 88 tests, plus lint clean.
