### PR TITLE
Speed up C decode: cache types, skip the ExactLatLong detour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v3.3.0
+======
+
+ * [perf] reworked the C decode path: cache the LatLong/ExactLatLong types instead of importing them per call, decode straight into a LatLong without building and discarding an intermediate ExactLatLong, and construct the result tuple directly (decode ~3x faster, bounding box ~1.5x faster)
+ * [perf] trimmed the Python wrappers: dropped redundant per-character validation (the C extension already validates) and per-call debug logging from the encode/decode/bounding-box hot paths
+ * [bugfix] fixed a latent out-of-bounds read in the C decoder for input bytes >= 128 (e.g. multibyte UTF-8); these are now cleanly rejected as invalid characters
+ * [tests] added a cross-library benchmark suite comparing pygeohash against other geohash libraries, behind an optional 'benchmark' extra
+
 v3.2.2
 ======
 

--- a/pygeohash/cgeohash/geohash_module.c
+++ b/pygeohash/cgeohash/geohash_module.c
@@ -54,30 +54,76 @@ static PyObject* geohash_get_base32(PyObject *self, PyObject *args) {
     return PyUnicode_FromString(BASE32);
 }
 
-// Decode a geohash string to exact latitude/longitude with error margins
-static PyObject* geohash_decode_exactly(PyObject *self, PyObject *args) {
-    const char *geohash;
-    
-    if (!PyArg_ParseTuple(args, "s", &geohash)) {
+// Cached LatLong / ExactLatLong named-tuple classes from pygeohash.geohash_types.
+// Importing the module and looking up the class on every decode call was a large
+// share of decode's cost, so we resolve them once and hold the references for the
+// lifetime of the process.
+static PyObject *LatLong_type = NULL;
+static PyObject *ExactLatLong_type = NULL;
+
+static int ensure_types(void) {
+    if (LatLong_type != NULL) {
+        return 0;
+    }
+    PyObject *module = PyImport_ImportModule("pygeohash.geohash_types");
+    if (!module) {
+        return -1;
+    }
+    LatLong_type = PyObject_GetAttrString(module, "LatLong");
+    ExactLatLong_type = PyObject_GetAttrString(module, "ExactLatLong");
+    Py_DECREF(module);
+    if (!LatLong_type || !ExactLatLong_type) {
+        Py_CLEAR(LatLong_type);
+        Py_CLEAR(ExactLatLong_type);
+        return -1;
+    }
+    return 0;
+}
+
+// Build a named-tuple instance (LatLong / ExactLatLong) from a values tuple.
+//
+// A typing.NamedTuple is a plain tuple subclass whose generated __new__ does
+// `tuple.__new__(cls, (field0, field1, ...))`. Calling the type the normal way
+// (PyObject_CallFunction) pays for that extra Python-level __new__ on every
+// decode. We skip it by invoking tuple's tp_new directly, which is exactly the
+// operation the generated __new__ performs. `values` is consumed (stolen).
+static PyObject* make_named_tuple(PyObject *type, PyObject *values) {
+    if (!values) {
         return NULL;
     }
-    
+    PyObject *call_args = PyTuple_Pack(1, values);  // tuple.__new__(type, values)
+    Py_DECREF(values);
+    if (!call_args) {
+        return NULL;
+    }
+    PyObject *result = PyTuple_Type.tp_new((PyTypeObject *)type, call_args, NULL);
+    Py_DECREF(call_args);
+    return result;
+}
+
+// Core decode: walk the geohash bits into a center point and error margins.
+// Returns 0 on success, -1 on an invalid character (with a Python exception set).
+static int decode_to_doubles(const char *geohash, double *out_lat, double *out_lon,
+                             double *out_lat_err, double *out_lon_err) {
     double lat_interval[2] = {-90.0, 90.0};
     double lon_interval[2] = {-180.0, 180.0};
     double lat_err = 90.0;
     double lon_err = 180.0;
     int is_even = 1;
-    int len = strlen(geohash);
-    
+    size_t len = strlen(geohash);
+
     init_base32_decode_map();
-    
-    for (int i = 0; i < len; i++) {
-        int cd = base32_decode_map[(int)geohash[i]];
+
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)geohash[i];
+        // Guard the table lookup: bytes >= 128 (e.g. multibyte UTF-8) must not
+        // index past base32_decode_map, they are simply invalid.
+        int cd = (c < 128) ? base32_decode_map[c] : -1;
         if (cd == -1) {
             PyErr_SetString(PyExc_ValueError, "Invalid character in geohash");
-            return NULL;
+            return -1;
         }
-        
+
         // Process each bit of the base32 character
         for (int mask = 16; mask > 0; mask >>= 1) {
             if (is_even) {  // longitude
@@ -98,84 +144,50 @@ static PyObject* geohash_decode_exactly(PyObject *self, PyObject *args) {
             is_even = !is_even;
         }
     }
-    
-    double lat = (lat_interval[0] + lat_interval[1]) / 2.0;
-    double lon = (lon_interval[0] + lon_interval[1]) / 2.0;
-    
-    // Get the ExactLatLong named tuple class from the geohash_types module
-    PyObject *module = PyImport_ImportModule("pygeohash.geohash_types");
-    if (!module) {
+
+    *out_lat = (lat_interval[0] + lat_interval[1]) / 2.0;
+    *out_lon = (lon_interval[0] + lon_interval[1]) / 2.0;
+    *out_lat_err = lat_err;
+    *out_lon_err = lon_err;
+    return 0;
+}
+
+// Decode a geohash string to exact latitude/longitude with error margins
+static PyObject* geohash_decode_exactly(PyObject *self, PyObject *args) {
+    const char *geohash;
+
+    if (!PyArg_ParseTuple(args, "s", &geohash)) {
         return NULL;
     }
-    
-    PyObject *exactlatlongClass = PyObject_GetAttrString(module, "ExactLatLong");
-    Py_DECREF(module);
-    if (!exactlatlongClass) {
+
+    double lat, lon, lat_err, lon_err;
+    if (decode_to_doubles(geohash, &lat, &lon, &lat_err, &lon_err) != 0) {
         return NULL;
     }
-    
-    // Create a new ExactLatLong instance
-    PyObject *args_tuple = Py_BuildValue("dddd", lat, lon, lat_err, lon_err);
-    PyObject *exactlatlongInstance = PyObject_CallObject(exactlatlongClass, args_tuple);
-    
-    Py_DECREF(exactlatlongClass);
-    Py_DECREF(args_tuple);
-    
-    return exactlatlongInstance;
+    if (ensure_types() != 0) {
+        return NULL;
+    }
+    return make_named_tuple(ExactLatLong_type, Py_BuildValue("dddd", lat, lon, lat_err, lon_err));
 }
 
 // Python wrapper for decode function
 static PyObject* geohash_decode(PyObject *self, PyObject *args) {
     const char *geohash;
-    
+
     if (!PyArg_ParseTuple(args, "s", &geohash)) {
         return NULL;
     }
-    
-    // Call decode_exactly to get the coordinates and error margins
-    PyObject *exact_result = geohash_decode_exactly(self, args);
-    if (!exact_result) {
+
+    // Decode straight into a LatLong: no intermediate ExactLatLong, no second
+    // module import, no attribute round-trip.
+    double lat, lon, lat_err, lon_err;
+    if (decode_to_doubles(geohash, &lat, &lon, &lat_err, &lon_err) != 0) {
         return NULL;
     }
-    
-    // Extract values from the ExactLatLong tuple
-    PyObject *lat_obj = PyObject_GetAttrString(exact_result, "latitude");
-    PyObject *lon_obj = PyObject_GetAttrString(exact_result, "longitude");
-    
-    if (!lat_obj || !lon_obj) {
-        Py_XDECREF(lat_obj);
-        Py_XDECREF(lon_obj);
-        Py_DECREF(exact_result);
+    if (ensure_types() != 0) {
         return NULL;
     }
-    
-    double lat = PyFloat_AsDouble(lat_obj);
-    double lon = PyFloat_AsDouble(lon_obj);
-    
-    Py_DECREF(lat_obj);
-    Py_DECREF(lon_obj);
-    Py_DECREF(exact_result);
-    
-    // Get the LatLong named tuple class from the geohash_types module
-    PyObject *module = PyImport_ImportModule("pygeohash.geohash_types");
-    if (!module) {
-        return NULL;
-    }
-    
-    PyObject *latlongClass = PyObject_GetAttrString(module, "LatLong");
-    Py_DECREF(module);
-    if (!latlongClass) {
-        return NULL;
-    }
-    
-    // Create a new LatLong instance
-    PyObject *args_tuple = Py_BuildValue("dd", lat, lon);
-    PyObject *latlongInstance = PyObject_CallObject(latlongClass, args_tuple);
-    
-    Py_DECREF(latlongClass);
-    Py_DECREF(args_tuple);
-    
-    return latlongInstance;
+    return make_named_tuple(LatLong_type, Py_BuildValue("dd", lat, lon));
 }
 
 // Encode coordinates to a geohash string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygeohash"
-version = "3.2.2"
+version = "3.3.0"
 description = "Python module for interacting with geohashes"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ dependencies = []
 [project.urls]
 "Homepage" = "https://pygeohash.mcginniscommawill.com"
 "Bug Tracker" = "https://github.com/wdm0006/pygeohash/issues"
-"Download" = "https://github.com/wdm0006/pygeohash/tarball/3.2.0"
+"Download" = "https://github.com/wdm0006/pygeohash/tarball/3.3.0"
 
 [tool.setuptools]
 packages = ["pygeohash", "pygeohash.cgeohash"]

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -113,6 +113,32 @@ def test_decode_invalid_chars():
         pgh.decode("ezs!2")  # '!' is invalid
 
 
+def test_decode_non_ascii():
+    """Non-ASCII input must be rejected cleanly, not read out of bounds.
+
+    The C decoder indexes a 128-entry table by character; bytes >= 128 (such as
+    multibyte UTF-8) must be treated as invalid rather than indexing past it.
+    """
+    for bad in ["café", "ñ", "ezs42°", "日本語", "ezs42\x80"]:
+        with pytest.raises(ValueError, match="Invalid character in geohash"):
+            pgh.decode(bad)
+        with pytest.raises(ValueError, match="Invalid character in geohash"):
+            pgh.decode_exactly(bad)
+
+
+def test_decode_return_types():
+    """decode/decode_exactly return the documented named tuples with named fields."""
+    from pygeohash.geohash_types import ExactLatLong, LatLong
+
+    latlong = pgh.decode("ezs42")
+    assert isinstance(latlong, LatLong)
+    assert latlong == (latlong.latitude, latlong.longitude)
+
+    exact = pgh.decode_exactly("ezs42")
+    assert isinstance(exact, ExactLatLong)
+    assert exact.latitude_error > 0 and exact.longitude_error > 0
+
+
 def test_decode_exactly_invalid_type():
     """Test decode_exactly with invalid input type."""
     with pytest.raises(ValueError, match="Geohash must be a string"):


### PR DESCRIPTION
## What

Speeds up `decode` and `decode_exactly` in the C extension by removing redundant object work, not by changing the geohash math. Follow-up to #58, which closed the Python-wrapper overhead and left the C extension as the remaining bottleneck (`decode` was still ~4.4x slower than the C++ `python-geohash`).

## The problem

The old `decode` path did a startling amount of work for what should be a few dozen floating-point operations:

1. `geohash_decode` called `geohash_decode_exactly`, which built an `ExactLatLong` namedtuple...
2. ...then `geohash_decode` tore that apart with two `PyObject_GetAttrString` calls, converted the floats back, **threw the namedtuple away**, and built a `LatLong`. Every decode constructed two namedtuples, one of them discarded.
3. Both functions ran `PyImport_ImportModule("pygeohash.geohash_types")` and an attribute lookup **on every call** to find the namedtuple classes.

## The change

- Pull the bit-decoding into a pure-C helper, `decode_to_doubles`, that fills four `double`s.
- Cache the `LatLong` / `ExactLatLong` type objects once for the process lifetime instead of importing the module per call.
- Build the result tuple directly. `decode` no longer constructs an `ExactLatLong` at all.
- Construct the namedtuple via tuple's `tp_new`, which is exactly the operation a `typing.NamedTuple`'s generated `__new__` performs internally (`tuple.__new__(cls, (...))`), skipping the Python-level `__new__` call. Worth ~36 ns/call.

Also fixes a latent out-of-bounds read: `base32_decode_map[(int)geohash[i]]` indexed past the 128-entry table for any byte >= 128 (e.g. multibyte UTF-8). Those bytes are now correctly rejected as invalid characters.

## Results

Same machine, `tests/test_benchmark_comparison.py` (mean):

| Operation | Before (#58) | After | Improvement |
|---|---:|---:|---:|
| decode | 959 ns | 318 ns | **67% faster** |
| bounding box | 758 ns | 484 ns | **36% faster** |
| encode | 207 ns | 207 ns | untouched (already on par) |

That moves `decode` from roughly 4.4x slower than `python-geohash` to about 1.2-1.4x. Bounding box improves because it decodes internally. The remaining gap to `python-geohash` is mostly that we return a `LatLong`/`BoundingBox` namedtuple where it returns a bare tuple, which is a deliberate API choice.

## Safety

- Return types, field names, and values are unchanged (`isinstance` against `LatLong`/`ExactLatLong` still holds; fields still accessible by name).
- The `"Invalid character in geohash"` error message is preserved, so existing `pytest.raises` assertions still match.
- Full suite passes: 88 tests.
