### PR TITLE
Keep bounding-box enumeration within geographic limits

### DIFF
--- a/pygeohash/bounding_box.py
+++ b/pygeohash/bounding_box.py
@@ -167,10 +167,10 @@ def geohashes_in_box(bbox: BoundingBox, precision: int = 6) -> List[str]:
 
     # Calculate the starting points slightly outside the bounding box
     # to ensure we cover the entire area
-    start_lat: float = bbox.min_lat - lat_step
-    end_lat: float = bbox.max_lat + lat_step
-    start_lon: float = bbox.min_lon - lon_step
-    end_lon: float = bbox.max_lon + lon_step
+    start_lat: float = max(bbox.min_lat - lat_step, -90.0)
+    end_lat: float = min(bbox.max_lat + lat_step, 90.0)
+    start_lon: float = max(bbox.min_lon - lon_step, -180.0)
+    end_lon: float = min(bbox.max_lon + lon_step, 180.0)
     logger.debug("Search area: lat=[%f, %f], lon=[%f, %f]", start_lat, end_lat, start_lon, end_lon)
 
     # Sample points in a grid pattern with spacing based on geohash size

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -165,3 +165,19 @@ class TestBoundingBox:
         mid_geohash = encode(mid_lat, mid_lon, 3)
 
         assert mid_geohash in result_interior
+
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            BoundingBox(-90.0, 0.0, -89.9, 0.1),
+            BoundingBox(89.9, 0.0, 90.0, 0.1),
+            BoundingBox(0.0, -180.0, 0.1, -179.9),
+            BoundingBox(0.0, 179.9, 0.1, 180.0),
+        ],
+    )
+    def test_geohashes_in_box_at_world_boundaries(self, bbox):
+        """Test boxes touching geographic limits return intersecting geohashes."""
+        result = geohashes_in_box(bbox, precision=4)
+
+        assert result
+        assert all(do_boxes_intersect(bbox, get_bounding_box(geohash)) for geohash in result)


### PR DESCRIPTION
Closes #67

## Summary

- clamp expanded latitude samples to -90..90
- clamp expanded longitude samples to -180..180
- cover boxes touching each world boundary and verify every returned cell intersects the request

## Verification

- `uv run pytest tests/test_bounding_box.py` — 10 passed
- `make test` — 103 passed
- `make lint` — mypy and Ruff passed
- `uv build` — wheel and source distribution built successfully