### PR TITLE
Reject non-finite coordinates in C encoders

### DIFF
--- a/pygeohash/cgeohash/geohash_module.c
+++ b/pygeohash/cgeohash/geohash_module.c
@@ -202,6 +202,11 @@ static PyObject* geohash_encode(PyObject *self, PyObject *args, PyObject *kwargs
         return NULL;
     }
 
+    if (!isfinite(latitude) || !isfinite(longitude)) {
+        PyErr_SetString(PyExc_ValueError, "latitude and longitude must be finite");
+        return NULL;
+    }
+
     // Bounds-check precision before writing into the fixed-size geohash[13]
     // buffer below: any value > 12 would overrun it (stack buffer overflow).
     if (precision < 1 || precision > 12) {
@@ -274,6 +279,11 @@ static PyObject* geohash_encode_strictly(PyObject *self, PyObject *args, PyObjec
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "dd|i", kwlist,
                                     &latitude, &longitude, &precision)) {
+        return NULL;
+    }
+
+    if (!isfinite(latitude) || !isfinite(longitude)) {
+        PyErr_SetString(PyExc_ValueError, "latitude and longitude must be finite");
         return NULL;
     }
 
@@ -362,4 +372,4 @@ static struct PyModuleDef geohashmodule = {
 // Module initialization function
 PyMODINIT_FUNC PyInit_geohash_module(void) {
     return PyModule_Create(&geohashmodule);
-} 
+}

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -109,6 +109,32 @@ def test_c_encode_validates_precision_directly():
         assert c_func(42.6, -5.6, 12) == "ezs42e44yx96"
 
 
+def test_c_encode_rejects_non_finite_coordinates():
+    from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
+
+    for c_func in (c_encode, c_encode_strictly):
+        for latitude, longitude in (
+            (float("inf"), 0.0),
+            (float("-inf"), 0.0),
+            (float("nan"), 0.0),
+            (0.0, float("inf")),
+            (0.0, float("-inf")),
+            (0.0, float("nan")),
+        ):
+            with pytest.raises(ValueError, match="latitude and longitude must be finite"):
+                c_func(latitude, longitude)
+
+
+def test_c_encode_preserves_finite_coordinate_normalization():
+    from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
+
+    for c_func in (c_encode, c_encode_strictly):
+        assert c_func(91.0, 0.0, 5) == c_func(90.0, 0.0, 5)
+        assert c_func(-91.0, 0.0, 5) == c_func(-90.0, 0.0, 5)
+        assert c_func(0.0, 181.0, 5) == c_func(0.0, -179.0, 5)
+        assert c_func(0.0, -181.0, 5) == c_func(0.0, 179.0, 5)
+
+
 def test_encode_strictly_invalid_latitude():
     """Test encode_strictly with invalid latitude values."""
     with pytest.raises(ValueError, match="Latitude must be between -90.0 and 90.0 degrees"):


### PR DESCRIPTION
Closes #66

## Summary
- reject NaN and infinite latitude or longitude in both low-level C encoder entry points before clamping or normalization
- add direct C-extension regression coverage for every non-finite coordinate position
- preserve and test finite latitude clamping and longitude wrapping behavior

## Verification
- `uv run pytest tests/test_geohash.py -q` — 27 passed
- `uv run pytest` — 101 passed
- `uv run ruff format . --check` — passed
- `uv run ruff check .` — passed
- `uv run mypy pygeohash` — passed
- `uv run tox` — Python 3.12 passed all 101 tests; unavailable interpreters skipped; the host Xcode Python 3.9 environment failed collection because the in-tree CPython 3.12 extension shadows its installed extension (CI provisions Python 3.12)
- `uv build` — sdist and CPython 3.12 wheel built successfully