### PR TITLE
Ship the PEP 561 marker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include LICENSE.txt
 include CHANGELOG.md
 include Makefile
 recursive-include pygeohash *.py
+include pygeohash/py.typed
 recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
 ]
 keywords = ["geohash", "gis"]
 dependencies = []
@@ -30,7 +31,7 @@ dependencies = []
 packages = ["pygeohash", "pygeohash.cgeohash"]
 
 [tool.setuptools.package-data]
-pygeohash = ["cgeohash/*.c", "cgeohash/*.h"]
+pygeohash = ["py.typed", "cgeohash/*.c", "cgeohash/*.h"]
 
 [project.optional-dependencies]
 viz = [


### PR DESCRIPTION
Include the py.typed marker in both the wheel and source distribution so downstream type checkers can use the package's existing inline annotations and native-extension stub. Advertise the package as typed in its PyPI metadata.

Refs #72.