### PR TITLE
Return zero approximate distance for identical geohashes

### DIFF
--- a/pygeohash/distances.py
+++ b/pygeohash/distances.py
@@ -73,6 +73,9 @@ def geohash_approximate_distance(geohash_1: str, geohash_2: str, check_validity:
             logger.error("Invalid geohash 2: %s", geohash_2)
             raise ValueError(f"Geohash 2: {geohash_2} is not a valid geohash")
 
+    if geohash_1 == geohash_2:
+        return 0.0
+
     # normalize the geohashes to the length of the shortest
     len_1 = len(geohash_1)
     len_2 = len(geohash_2)

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -228,6 +228,16 @@ def test_check_validity():
         pgh.geohash_approximate_distance("shibu", "shiba", check_validity=True)
 
 
+def test_approximate_distance_checks_identical_invalid_geohashes():
+    with pytest.raises(ValueError):
+        pgh.geohash_approximate_distance("invalid", "invalid", check_validity=True)
+
+
+@pytest.mark.parametrize("geohash", ["s", "u4pruydqqvjk"])
+def test_approximate_distance_is_zero_for_identical_geohashes(geohash):
+    assert pgh.geohash_approximate_distance(geohash, geohash) == 0.0
+
+
 def test_distance():
     # test the fast geohash distance approximations
     assert pgh.geohash_approximate_distance("bcd3u", "bc83n") == 625441


### PR DESCRIPTION
Closes #71

## Summary

- return `0.0` when both geohash strings are identical
- keep optional validity checks ahead of the equality fast path
- cover identical hashes at precisions 1 and 12, invalid identical inputs, and retain existing distinct-input estimates

## Verification

- `uv run pytest tests/test_geohash.py` — 30 passed
- `uv run pytest` — 108 passed
- `make lint` — mypy and ruff passed
- mutation check: removed the equality branch and ran `uv run pytest tests/test_geohash.py -k approximate_distance_is_zero_for_identical_geohashes` — both regression cases failed with the former nonzero values; restored the branch and reran the focused approximate-distance tests — 3 passed
- `uv run tox` — Python 3.12 passed all 108 tests; Python 3.9 hit a pre-existing source-tree collection failure because the local compiled extension is unavailable for that interpreter (Python 3.8/3.10/3.11 were skipped)