### PR TITLE
ci: efficiency + hygiene tuning

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
@@ -14,6 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -57,4 +58,4 @@ jobs:
           pip-audit --path .
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3 
+        uses: actions/dependency-review-action@v4 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,19 @@ on:
   push:
     branches: [main, master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v5
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'  # Use the latest Python for running tox
         

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI efficiency + hygiene tuning for GitHub Actions workflows.

- Bump `actions/checkout@v3 → v5` and `actions/setup-python@v4 → v5` in `publish-pypi.yml` and `test.yml`
- Bump `actions/dependency-review-action@v3 → v4` in `security.yml`
- Cache pip deps (`cache: 'pip'`) on the `setup-python` steps in `code-quality.yml` and `security.yml`
- Add `concurrency: cancel-in-progress` to `test.yml`, `code-quality.yml`, and `validate-docs.yml` so superseded PR runs are cancelled (intentionally NOT added to `publish-pypi.yml`, the Pages-deploy `publish-docs.yml`, or the CodeQL `security.yml`)

Recommendation (not applied): `security.yml` runs the full CodeQL analysis on every pull request, which is one of the more expensive per-PR jobs. Consider moving CodeQL to a `push`/`schedule` trigger (e.g. weekly + on pushes to `master`) to cut per-PR CI cost while keeping coverage.
