### PR TITLE
ci: move CodeQL off per-PR to push + weekly schedule

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,19 @@
 name: "Security"
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   codeql:
     name: CodeQL Analysis
+    # CodeQL autobuild is expensive; run it on merges to master and weekly
+    # rather than on every PR. PRs are still gated by dependency review below.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -33,6 +40,9 @@ jobs:
 
   dependency-security:
     name: Dependency Security
+    # dependency-review-action only runs on pull_request events, so this job is
+    # PR-only; it keeps the fast per-PR supply-chain gate that CodeQL no longer provides.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to the CI tuning PR (which merged before this landed): the `Security` workflow runs a full **CodeQL autobuild on every PR**, which is the slowest per-PR job.

- Gate the `codeql` job to `push` (master) + a weekly `schedule` via `if: github.event_name != 'pull_request'` — CodeQL still runs on every merge to master and weekly, just not on each PR.
- Keep the `dependency-security` job (pip-audit + dependency-review) **PR-only** (`dependency-review-action` only works on `pull_request` events), so PRs retain a fast supply-chain gate.
- No branch protection requires the CodeQL check, so this blocks nothing.
