### PR TITLE
Gate docstring examples with doctest

### DIFF
--- a/pygeohash/bounding_box.py
+++ b/pygeohash/bounding_box.py
@@ -42,8 +42,8 @@ def get_bounding_box(geohash: str) -> BoundingBox:
             values that define the bounding box of the geohash.
 
     Example:
-        >>> get_bounding_box("u4pruyd")
-        BoundingBox(min_lat=57.649, min_lon=10.407, max_lat=57.649, max_lon=10.407)
+        >>> tuple(round(value, 6) for value in get_bounding_box("u4pruyd"))
+        (57.64801, 10.406799, 57.649384, 10.408173)
 
     Note:
         The precision of the coordinates in the bounding box depends on the length
@@ -141,7 +141,7 @@ def geohashes_in_box(bbox: BoundingBox, precision: int = 6) -> List[str]:
     Example:
         >>> box = BoundingBox(57.64, 10.40, 57.65, 10.41)
         >>> geohashes_in_box(box, precision=5)
-        ['u4pru', 'u4prv']
+        ['u4pru']
 
     Note:
         The number of geohashes returned depends on the size of the bounding box

--- a/pygeohash/distances.py
+++ b/pygeohash/distances.py
@@ -58,7 +58,7 @@ def geohash_approximate_distance(geohash_1: str, geohash_2: str, check_validity:
 
     Example:
         >>> geohash_approximate_distance("u4pruyd", "u4pruyf")
-        118.0
+        610
     """
     logger.debug(
         "Calculating approximate distance between %s and %s (check_validity=%s)", geohash_1, geohash_2, check_validity
@@ -114,8 +114,8 @@ def geohash_haversine_distance(geohash_1: str, geohash_2: str) -> float:
         float: The distance in meters.
 
     Example:
-        >>> geohash_haversine_distance("u4pruyd", "u4pruyf")
-        152.3
+        >>> round(geohash_haversine_distance("u4pruyd", "u4pruyf"), 1)
+        152.7
     """
     logger.debug("Calculating haversine distance between %s and %s", geohash_1, geohash_2)
 

--- a/pygeohash/stats.py
+++ b/pygeohash/stats.py
@@ -162,7 +162,7 @@ def mean(geohashes: GeohashCollection, precision: GeohashPrecision = 12) -> str:
 
     Example:
         >>> mean(["u4pruyd", "u4pruyf", "u4pruyc"])
-        'u4pruye'
+        'u4pruyf1m6dt'
     """
     logger.debug("Calculating mean position for %d geohashes with precision %d", len(geohashes), precision)
 
@@ -193,8 +193,8 @@ def variance(geohashes: GeohashCollection) -> float:
         float: The variance in meters squared.
 
     Example:
-        >>> variance(["u4pruyd", "u4pruyf", "u4pruyc"])
-        2500.0
+        >>> round(variance(["u4pruyd", "u4pruyf", "u4pruyc"]), 1)
+        6665.5
     """
     logger.debug("Calculating variance for %d geohashes", len(geohashes))
 
@@ -223,8 +223,8 @@ def std(geohashes: GeohashCollection) -> float:
         float: The standard deviation in meters.
 
     Example:
-        >>> std(["u4pruyd", "u4pruyf", "u4pruyc"])
-        50.0
+        >>> round(std(["u4pruyd", "u4pruyf", "u4pruyc"]), 1)
+        81.6
     """
     logger.debug("Calculating standard deviation for %d geohashes", len(geohashes))
     result = math.sqrt(variance(geohashes))

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,18 @@
+"""Run the examples in dependency-free package modules as doctests."""
+
+import doctest
+from types import ModuleType
+from typing import Tuple
+
+from pygeohash import bounding_box, distances, geohash, geohash_types, neighbor, stats, types
+
+
+def test_docstring_examples() -> None:
+    modules: Tuple[ModuleType, ...] = (geohash, distances, neighbor, bounding_box, stats, types, geohash_types)
+    results = {module.__name__: doctest.testmod(module, raise_on_error=False) for module in modules}
+    failures = {name: result.failed for name, result in results.items() if result.failed}
+
+    assert failures == {}
+    assert sum(result.attempted for result in results.values()) == 21
+    for module in (distances, bounding_box, stats, neighbor):
+        assert results[module.__name__].attempted > 0


### PR DESCRIPTION
Closes #80

## Summary

- correct all stale doctest outputs in the dependency-free distance, bounding-box, and statistics modules
- use rounded numeric examples for floating-point results to keep the documentation stable and readable
- add an explicit doctest gate for `geohash`, `distances`, `neighbor`, `bounding_box`, `stats`, `types`, and `geohash_types`
- assert that all 21 examples are collected and that each expected example-bearing module has a nonzero attempted count

`viz.py` remains follow-up work: its examples construct matplotlib figures and require the optional plotting stack, so it is intentionally outside the default dependency-free gate.

## Verification

- `make test` — 109 passed
- `make lint` — mypy and Ruff passed
- `uv run pytest tests/test_doctests.py -q` — 1 passed; all 21 doctests completed with zero failures
- copied `tests/test_doctests.py` into a detached fresh `master` worktree and ran it — failed as intended with 11 failures (`distances`: 2, `bounding_box`: 2, `stats`: 7), proving the gate is non-vacuous

The test lives under the configured `testpaths = ["tests"]`, so both `make test` and the tox `pytest tests` command collect it.
