### PR TITLE
Use canonical validation for approximate distance

### DIFF
--- a/pygeohash/distances.py
+++ b/pygeohash/distances.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import math
 from typing import Dict, Final
 
-from pygeohash.geohash import __base32, decode_exactly
+from pygeohash.geohash import decode_exactly
 from pygeohash.geohash_types import ExactLatLong
 from pygeohash.logging import get_logger
+from pygeohash.types import is_valid_geohash
 
 logger = get_logger(__name__)
 
@@ -65,13 +66,16 @@ def geohash_approximate_distance(geohash_1: str, geohash_2: str, check_validity:
     )
 
     if check_validity:
-        if len([x for x in geohash_1 if x in __base32]) != len(geohash_1):
+        if not is_valid_geohash(geohash_1):
             logger.error("Invalid geohash 1: %s", geohash_1)
             raise ValueError(f"Geohash 1: {geohash_1} is not a valid geohash")
 
-        if len([x for x in geohash_2 if x in __base32]) != len(geohash_2):
+        if not is_valid_geohash(geohash_2):
             logger.error("Invalid geohash 2: %s", geohash_2)
             raise ValueError(f"Geohash 2: {geohash_2} is not a valid geohash")
+
+        geohash_1 = geohash_1.lower()
+        geohash_2 = geohash_2.lower()
 
     if geohash_1 == geohash_2:
         return 0.0

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -233,6 +233,33 @@ def test_approximate_distance_checks_identical_invalid_geohashes():
         pgh.geohash_approximate_distance("invalid", "invalid", check_validity=True)
 
 
+@pytest.mark.parametrize("geohash", ["", "u4pruydqqvjkc"])
+def test_approximate_distance_rejects_invalid_length(geohash):
+    with pytest.raises(ValueError):
+        pgh.geohash_approximate_distance(geohash, "u4pruyd", check_validity=True)
+
+
+@pytest.mark.parametrize(
+    "geohash_1, geohash_2",
+    [
+        ("U4PRUYD", "U4PRUYF"),
+        ("u4PRuyD", "U4pRUyf"),
+    ],
+)
+def test_approximate_distance_normalizes_validated_geohashes(geohash_1, geohash_2):
+    expected = pgh.geohash_approximate_distance(geohash_1.lower(), geohash_2.lower(), check_validity=True)
+    assert pgh.geohash_approximate_distance(geohash_1, geohash_2, check_validity=True) == expected
+
+
+def test_approximate_distance_skips_validation_by_default(monkeypatch):
+    def fail_validation(_geohash):
+        raise AssertionError("validation should not run")
+
+    monkeypatch.setattr("pygeohash.distances.is_valid_geohash", fail_validation)
+    assert pgh.geohash_approximate_distance("", "") == 0.0
+    assert pgh.geohash_approximate_distance("u4pruydqqvjkc", "u4pruydqqvjkd") == 0.6
+
+
 @pytest.mark.parametrize("geohash", ["s", "u4pruydqqvjk"])
 def test_approximate_distance_is_zero_for_identical_geohashes(geohash):
     assert pgh.geohash_approximate_distance(geohash, geohash) == 0.0


### PR DESCRIPTION
Closes #84

## Summary

- use `is_valid_geohash` for opt-in approximate-distance validation
- normalize validated geohashes to lowercase before equality and prefix comparison
- cover empty, overlength, uppercase, mixed-case, identical-invalid, and permissive fast-path behavior

## Verification

- `.venv/bin/python -m pytest -q` — 133 passed
- `.venv/bin/python -m pytest tests/test_geohash.py -q -k approximate_distance` — 8 passed
- `.venv/bin/ruff format . --check` — 35 files already formatted
- `.venv/bin/ruff check .` — all checks passed
- `uvx -p 3.11 --from mypy --with . --with pandas-stubs --with types-requests --with types-setuptools mypy pygeohash` — success, no issues in 13 source files
- mutation checks: disabling validation failed all 3 invalid-input regressions; disabling lowercase normalization failed the mixed-case regression