### PR TITLE
fix: compute geohash mean longitude as a circular mean

### DIFF
--- a/pygeohash/stats.py
+++ b/pygeohash/stats.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import math
 import statistics
-from typing import Callable, Final, TypeVar
+from typing import Callable, Final, Sequence, TypeVar
 
 from pygeohash.distances import geohash_haversine_distance
 from pygeohash.geohash import decode, encode
@@ -22,6 +22,38 @@ logger = get_logger(__name__)
 __author__: Final[str] = "Will McGinnis"
 
 T = TypeVar("T")
+
+#: Resultant vector lengths at or below this value are treated as fully cancelled.
+_CIRCULAR_MEAN_TOLERANCE: Final[float] = 1e-12
+
+
+def _circular_mean_longitude(longitudes: Sequence[float]) -> float:
+    """Calculate the circular mean of a sequence of longitudes in degrees.
+
+    Longitude is circular, so an arithmetic mean places the centroid of a
+    collection spanning the antimeridian near the prime meridian instead. This
+    averages the unit vectors of the longitudes and converts the resultant back
+    to degrees.
+
+    When the resultant vector cancels out (for example two antipodal
+    longitudes), no unique circular mean exists and the arithmetic mean of the
+    longitudes is returned.
+
+    Args:
+        longitudes (Sequence[float]): Longitudes in degrees.
+
+    Returns:
+        float: The mean longitude in degrees, within [-180, 180].
+    """
+    radians = [math.radians(longitude) for longitude in longitudes]
+    mean_sin = statistics.mean(math.sin(radian) for radian in radians)
+    mean_cos = statistics.mean(math.cos(radian) for radian in radians)
+
+    if math.hypot(mean_sin, mean_cos) <= _CIRCULAR_MEAN_TOLERANCE:
+        logger.debug("Longitude vectors cancelled out; falling back to the arithmetic mean")
+        return statistics.mean(longitudes)
+
+    return math.degrees(math.atan2(mean_sin, mean_cos))
 
 
 def __latitude(coordinate: LatLong) -> float:
@@ -153,12 +185,19 @@ def western(geohashes: GeohashCollection) -> str:
 def mean(geohashes: GeohashCollection, precision: GeohashPrecision = 12) -> str:
     """Calculate the mean position of a collection of geohashes.
 
+    Latitude is averaged arithmetically. Longitude is averaged circularly, so a
+    collection spanning the antimeridian is centered near ±180 rather than near
+    the prime meridian. If the longitude vectors cancel out exactly (for example
+    two antipodal longitudes) no unique circular mean exists, and the arithmetic
+    mean of the longitudes is used instead.
+
     Args:
         geohashes (GeohashCollection): Collection of geohash strings.
         precision (GeohashPrecision, optional): The precision of the resulting geohash. Defaults to 12.
 
     Returns:
-        str: A geohash representing the mean position.
+        str: A geohash representing the mean position, or an empty string for an
+            empty collection.
 
     Example:
         >>> mean(["u4pruyd", "u4pruyf", "u4pruyc"])
@@ -173,7 +212,7 @@ def mean(geohashes: GeohashCollection, precision: GeohashPrecision = 12) -> str:
     coordinates = [decode(x) for x in geohashes]
     logger.debug("Decoded %d coordinates for mean calculation", len(coordinates))
     mean_lat = statistics.mean(c.latitude for c in coordinates)
-    mean_lon = statistics.mean(c.longitude for c in coordinates)
+    mean_lon = _circular_mean_longitude([c.longitude for c in coordinates])
 
     result = encode(mean_lat, mean_lon, precision)
     logger.debug("Mean position calculated: %s (lat=%f, lon=%f)", result, mean_lat, mean_lon)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,108 @@
+import math
+
+import pytest
+
+import pygeohash as pgh
+
+# Two cells about 2 degrees apart, straddling the antimeridian.
+WEST_OF_LINE = pgh.encode(0.0, 179.0)
+EAST_OF_LINE = pgh.encode(0.0, -179.0)
+
+
+def test_mean_across_antimeridian():
+    """A collection straddling the antimeridian is centered near +/-180, not near Greenwich."""
+    centroid = pgh.decode(pgh.mean([WEST_OF_LINE, EAST_OF_LINE]))
+
+    assert abs(centroid.longitude) == pytest.approx(180.0, abs=1e-4)
+    assert centroid.latitude == pytest.approx(0.0, abs=1e-4)
+
+
+def test_mean_across_antimeridian_asymmetric():
+    """An uneven cluster near the antimeridian leans toward its heavier side."""
+    geohashes = [
+        pgh.encode(10.0, 178.0),
+        pgh.encode(10.0, 179.0),
+        pgh.encode(10.0, -177.0),
+    ]
+
+    centroid = pgh.decode(pgh.mean(geohashes))
+
+    assert centroid.longitude == pytest.approx(180.0, abs=1e-3)
+    assert centroid.latitude == pytest.approx(10.0, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        [(42.6, -5.6), (42.7, -5.5), (42.5, -5.7)],
+        [(-33.9, 151.2), (-33.8, 151.3), (-34.0, 151.1)],
+        [(0.0, 0.0), (0.1, 0.1), (-0.1, -0.1)],
+        [(0.0, -45.0), (0.0, 0.0), (0.0, 45.0)],
+        [(60.0, -120.0), (60.0, -119.9)],
+    ],
+)
+def test_mean_matches_arithmetic_centroid_without_wrapping(coordinates):
+    """Clusters that do not cross the antimeridian keep their arithmetic centroid."""
+    geohashes = [pgh.encode(lat, lon) for lat, lon in coordinates]
+
+    centroid = pgh.decode(pgh.mean(geohashes))
+
+    assert centroid.latitude == pytest.approx(sum(lat for lat, _ in coordinates) / len(coordinates), abs=1e-4)
+    assert centroid.longitude == pytest.approx(sum(lon for _, lon in coordinates) / len(coordinates), abs=1e-4)
+
+
+def test_mean_of_wide_asymmetric_cluster_leans_toward_the_chord():
+    """A circular mean of a wide, lopsided cluster differs slightly from the arithmetic one."""
+    coordinates = [(51.5, -0.1), (48.9, 2.4), (52.5, 13.4)]
+    geohashes = [pgh.encode(lat, lon) for lat, lon in coordinates]
+
+    centroid = pgh.decode(pgh.mean(geohashes))
+    arithmetic = sum(lon for _, lon in coordinates) / len(coordinates)
+
+    assert centroid.longitude == pytest.approx(arithmetic, abs=0.01)
+    assert centroid.longitude != pytest.approx(arithmetic, abs=1e-4)
+
+
+def test_mean_of_antipodal_longitudes_is_deterministic():
+    """Fully cancelling longitudes have no unique circular mean, so the arithmetic mean is used."""
+    # decode("0") and decode("h") are centered exactly 180 degrees apart in longitude.
+    geohashes = ["0", "h"]
+    assert pgh.decode(geohashes[1]).longitude - pgh.decode(geohashes[0]).longitude == 180.0
+
+    centroid = pgh.decode(pgh.mean(geohashes))
+
+    assert centroid.longitude == pytest.approx(-67.5, abs=1e-4)
+    assert pgh.mean(geohashes) == pgh.mean(geohashes)
+    assert pgh.mean(list(reversed(geohashes))) == pgh.mean(geohashes)
+
+
+def test_std_across_antimeridian_reflects_true_spread():
+    """Spread statistics use the corrected centroid instead of an antipodal one."""
+    # Roughly 2 degrees apart at the equator, so each cell sits ~111 km from the centroid.
+    spread = pgh.std([WEST_OF_LINE, EAST_OF_LINE])
+
+    assert spread == pytest.approx(111_195.0, rel=1e-3)
+    assert pgh.variance([WEST_OF_LINE, EAST_OF_LINE]) == pytest.approx(spread**2, rel=1e-9)
+
+
+def test_std_without_wrapping_is_unchanged():
+    """A cluster away from the antimeridian keeps its previous spread."""
+    assert pgh.variance(["u4pruyd", "u4pruyf", "u4pruyc"]) == pytest.approx(6665.5, abs=0.1)
+    assert pgh.std(["u4pruyd", "u4pruyf", "u4pruyc"]) == pytest.approx(81.6, abs=0.1)
+
+
+@pytest.mark.parametrize("precision", [1, 5, 8, 12])
+def test_mean_honors_requested_precision(precision):
+    assert len(pgh.mean([WEST_OF_LINE, EAST_OF_LINE], precision)) == precision
+
+
+def test_mean_of_single_geohash_round_trips():
+    assert pgh.mean([EAST_OF_LINE]) == EAST_OF_LINE
+
+
+def test_empty_collection():
+    assert pgh.mean([]) == ""
+    assert pgh.mean([], 5) == ""
+    assert pgh.variance([]) == 0.0
+    assert pgh.std([]) == 0.0
+    assert not math.isnan(pgh.std([]))


### PR DESCRIPTION
Closes #68

## What changed

`mean()` averaged longitude arithmetically, so a collection spanning the antimeridian was centered near the prime meridian: cells at +179° and -179° are ~2° apart but averaged to ~0°, returning `s00000000000`. Because `variance()` calls `mean()`, the bad centroid also inflated spread statistics for those collections.

- New `_circular_mean_longitude()` helper in `pygeohash/stats.py` averages the unit vectors of the longitudes (`atan2(mean(sin), mean(cos))`).
- `mean()` uses it for longitude and keeps the arithmetic latitude mean. Requested precision, the empty-collection `""` return, and the public API are all unchanged.
- `variance()` / `std()` inherit the corrected centroid through `mean()` — no change needed at their call sites.
- New `tests/test_stats.py` (there was no stats test module; `stats.py` was only covered incidentally).

### Degenerate case

When the longitude vectors cancel exactly, no unique circular mean exists. The documented, deterministic fallback is the **arithmetic mean of the longitudes**, which for a cancelling pair is one of the two equidistant midpoints. This is reachable through the public API — geohash cell centers are quantized, so e.g. `decode("0")` and `decode("h")` are exactly 180° apart — and `mean(["0", "h"])` returns a stable result regardless of input order.

### Behavior note for reviewers

A circular mean is not the same estimator as an unwrapped arithmetic mean. Symmetric clusters agree exactly and tight clusters agree to sub-metre, but a **wide, asymmetric** cluster that does not wrap shifts slightly: London/Paris/Berlin (13.5° span) moves 6.3e-3° ≈ 700 m. Over a randomized sweep of ±3°-spread clusters the worst non-wrapping shift was 88.8 m. This is inherent to the sine/cosine approach the issue specifies, so I took it rather than a conditional unwrap-then-average; it is now stated in the `mean()` docstring.

## Verification

All commands run with a local `uv` venv (Python 3.12) in the worktree.

- `.venv/bin/python -m pytest tests/ -q` → **150 passed**. Every pre-existing assertion is untouched: `tests/test_geohash.py::test_stats` still expects `mean == "s00000000000"`, and the `mean` / `variance` / `std` doctests still produce `u4pruyf1m6dt` / `6665.5` / `81.6`.
- `ruff format . --check` → 36 files already formatted. `ruff check .` → All checks passed. `mypy pygeohash` → Success, 13 source files. (Ran all three separately, since the `code-quality` workflow's steps are sequential.)
- **Mutation test** — reinstated the arithmetic longitude mean and confirmed the new tests are not vacuous. 4 of the 17 fail with the bug back:
  - `test_mean_across_antimeridian` — centroid longitude 1.7e-07 instead of 180
  - `test_mean_across_antimeridian_asymmetric` — 60.0 instead of 180
  - `test_std_across_antimeridian_reflects_true_spread` — std 19,903,891 m instead of 111,195 m
  - `test_mean_of_wide_asymmetric_cluster_leans_toward_the_chord`

  The remaining 13 document preserved behavior and pass either way. In particular `test_mean_of_antipodal_longitudes_is_deterministic` **cannot** distinguish the two implementations — the degenerate fallback *is* the arithmetic mean — so it guards determinism and the documented value, not the fix. It does exercise the fallback branch (resultant length 5.6e-17, well under the 1e-12 tolerance).
- **Randomized sweep**, 3000 clusters of 2–8 cells at random centers: no exceptions raised (the circular mean always lands inside `encode()`'s valid longitude range), and all 35 clusters that genuinely wrapped got a centroid with equal or smaller circular spread than the arithmetic one.