### PR TITLE
ci: build Linux ARM64 wheels natively

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
     
     steps:
       - uses: actions/checkout@v5
@@ -21,12 +21,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Set up QEMU for cross-architecture builds
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Install cibuildwheel
         run: pip install cibuildwheel
       
@@ -35,7 +29,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"  # Skip PyPy and musllinux
           CIBW_ARCHS_MACOS: "x86_64 arm64"  # Build for Intel and Apple Silicon on macOS
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"  # Build for x86_64 and ARM64 on Linux
+          CIBW_ARCHS_LINUX: native  # Build each Linux architecture on its native runner
       
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Build Linux x86_64 and ARM64 wheels on matching GitHub-hosted runners. Native ARM64 removes QEMU emulation while preserving the existing Linux, macOS, and Windows wheel coverage.