### PR TITLE
test: stop the test suite from rewriting tracked files under examples/images/

### DIFF
--- a/examples/visualization_examples.py
+++ b/examples/visualization_examples.py
@@ -8,6 +8,7 @@ This example shows how to create different types of visualizations:
 """
 
 from pathlib import Path
+from typing import Optional
 
 import matplotlib.pyplot as plt
 
@@ -21,13 +22,16 @@ from pygeohash import (
     assert_valid_geohash,
 )
 
-# Ensure images directory exists
+# Default output directory for the generated images
 IMAGES_DIR = Path(__file__).parent / "images"
-IMAGES_DIR.mkdir(exist_ok=True)
 
 
-def demonstrate_single_geohash() -> None:
-    """Show how to plot a single geohash."""
+def demonstrate_single_geohash(output_dir: Path) -> None:
+    """Show how to plot a single geohash.
+
+    Args:
+        output_dir: Directory the generated PNG is written to.
+    """
     print("\nPlotting single geohash...")
 
     # Plot San Francisco geohash
@@ -36,12 +40,16 @@ def demonstrate_single_geohash() -> None:
 
     # Add title and save
     plt.title("San Francisco Geohash")
-    plt.savefig(IMAGES_DIR / "single_geohash.png")
+    plt.savefig(output_dir / "single_geohash.png")
     plt.close()
 
 
-def demonstrate_multiple_geohashes() -> None:
-    """Show how to plot multiple geohashes with different styles."""
+def demonstrate_multiple_geohashes(output_dir: Path) -> None:
+    """Show how to plot multiple geohashes with different styles.
+
+    Args:
+        output_dir: Directory the generated PNG is written to.
+    """
     print("\nPlotting multiple geohashes...")
 
     # Sample geohashes around SF Bay
@@ -62,12 +70,16 @@ def demonstrate_multiple_geohashes() -> None:
 
     # Add title and save
     plt.title("SF Bay Area Geohashes")
-    plt.savefig(IMAGES_DIR / "multiple_geohashes.png")
+    plt.savefig(output_dir / "multiple_geohashes.png")
     plt.close()
 
 
-def demonstrate_folium_map() -> None:
-    """Show how to create an interactive Folium map."""
+def demonstrate_folium_map(output_dir: Path) -> None:
+    """Show how to create an interactive Folium map.
+
+    Args:
+        output_dir: Directory the generated HTML map is written to.
+    """
     print("\nCreating Folium map...")
 
     # Sample geohashes (Silicon Valley tech companies)
@@ -98,19 +110,27 @@ def demonstrate_folium_map() -> None:
         colors=["red", "blue", "green", "purple"],
         tooltips=["Apple", "Google", "Meta", "Tesla"],
     )
-    m.save(IMAGES_DIR / "tech_companies.html")
+    m.save(output_dir / "tech_companies.html")
 
 
-def main() -> None:
-    """Run all demonstrations."""
+def main(output_dir: Optional[Path] = None) -> None:
+    """Run all demonstrations.
+
+    Args:
+        output_dir: Directory the generated files are written to. Defaults to the
+            ``images`` directory next to this script.
+    """
+    output_dir = IMAGES_DIR if output_dir is None else Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
     print("Visualization Examples")
     print("====================")
 
-    demonstrate_single_geohash()
-    demonstrate_multiple_geohashes()
-    demonstrate_folium_map()
+    demonstrate_single_geohash(output_dir)
+    demonstrate_multiple_geohashes(output_dir)
+    demonstrate_folium_map(output_dir)
 
-    print(f"\nVisualization files saved in: {IMAGES_DIR}")
+    print(f"\nVisualization files saved in: {output_dir}")
 
 
 if __name__ == "__main__":

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,7 @@ This module tests that all example scripts can run without errors.
 Each test captures stdout and verifies expected output is present.
 """
 
+import hashlib
 import io
 import sys
 import matplotlib
@@ -20,6 +21,23 @@ from examples import typed_data_analysis
 # Add examples directory to path
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 sys.path.append(str(EXAMPLES_DIR))
+
+# Files under examples/images/ that are tracked in git and must survive a test run
+TRACKED_IMAGE_NAMES = ("single_geohash.png", "multiple_geohashes.png", "tech_companies.html")
+
+
+def _snapshot_tracked_images() -> dict:
+    """Snapshot the tracked example images, keyed by file name.
+
+    Records a content hash and the modification time. The mtime matters: regenerating
+    these PNGs is byte-deterministic for a given matplotlib version, so a stray write
+    can reproduce the committed bytes exactly and a content-only check would miss it.
+    """
+    images_dir = EXAMPLES_DIR / "images"
+    return {
+        name: (hashlib.sha256((images_dir / name).read_bytes()).hexdigest(), (images_dir / name).stat().st_mtime_ns)
+        for name in TRACKED_IMAGE_NAMES
+    }
 
 
 def capture_output(func) -> str:
@@ -72,9 +90,11 @@ def test_statistical_analysis():
     assert "Standard deviation:" in output  # Should show dispersion stats
 
 
-def test_visualization_examples():
+def test_visualization_examples(tmp_path):
     """Test visualization_examples.py example runs without errors."""
-    output = capture_output(visualization_examples.main)
+    tracked_before = _snapshot_tracked_images()
+
+    output = capture_output(lambda: visualization_examples.main(tmp_path))
 
     # Verify key sections are present
     assert "Visualization Examples" in output
@@ -82,11 +102,12 @@ def test_visualization_examples():
     assert "Plotting multiple geohashes" in output
     assert "Creating Folium map" in output
 
-    # Verify files were created
-    images_dir = EXAMPLES_DIR / "images"
-    assert (images_dir / "single_geohash.png").exists()
-    assert (images_dir / "multiple_geohashes.png").exists()
-    assert (images_dir / "tech_companies.html").exists()
+    # Verify files were created, under the injected output directory
+    for name in TRACKED_IMAGE_NAMES:
+        assert (tmp_path / name).exists()
+
+    # The example must not touch the tracked copies under examples/images/
+    assert _snapshot_tracked_images() == tracked_before
 
 
 def test_typed_data_analysis():


### PR DESCRIPTION
Closes #89

## What changed

`examples/visualization_examples.py` wrote unconditionally to a module-level `IMAGES_DIR`, and `tests/test_examples.py::test_visualization_examples` drove that same write path — so every `pytest` run left three tracked files modified (`single_geohash.png`, `multiple_geohashes.png`, `tech_companies.html`).

- **`examples/visualization_examples.py`** — `main()` now takes `output_dir: Optional[Path] = None`, defaulting to `Path(__file__).parent / "images"`, and threads it through the three `demonstrate_*` helpers. The `mkdir` moved from import time into `main()`, so merely *importing* the module no longer touches the source tree.
- **`tests/test_examples.py`** — `test_visualization_examples` passes `tmp_path` and asserts all three artifacts exist there. The existing stdout assertions are unchanged.

No library code changed; `examples/images/` is not in this diff.

### Guard against regression

The test snapshots the three tracked files before the run and asserts they are untouched afterwards. The snapshot records **mtime alongside a content hash**, not bytes alone — see the note below for why a content-only check would have been contingent on the local matplotlib version.

## Verification

All commands run with `.venv/bin/python` (Python 3.12, `uv pip install -e ".[dev,viz]"`).

**Acceptance: clean tree after a full suite run.** Starting from a clean checkout:

```
$ git status --porcelain          # (empty)
$ .venv/bin/python -m pytest
============================= 150 passed in 5.42s ==============================
$ git status --porcelain          # (empty)
```

Before this change the same run left:

```
 M examples/images/multiple_geohashes.png
 M examples/images/single_geohash.png
 M examples/images/tech_companies.html
```

**Gates** — all green:

```
$ .venv/bin/python -m ruff format . --check   -> 36 files already formatted
$ .venv/bin/python -m ruff check .            -> All checks passed!
$ .venv/bin/python -m mypy pygeohash          -> Success: no issues found in 13 source files
```

(`mypy examples/visualization_examples.py` reports 6 errors, but the identical 6 are present on `master` — `examples/` is outside the CI gate, which is `mypy pygeohash`.)

**Default behavior unchanged.** `python examples/visualization_examples.py` still prints `Visualization files saved in: .../examples/images` and modifies exactly the same three files as before. `make viz-examples` is unaffected — it runs `scripts/generate_viz_examples.py`, which writes to `docs/source/_static/images` and never imports this example script.

**Mutation testing** — the guard was verified against two reverts, each from a clean tree, with the mutation confirmed present via `grep` before running:

| Mutation | Result |
|---|---|
| A — `main()` ignores `output_dir` and uses `IMAGES_DIR` (full revert) | **FAILED** — caught by the `tmp_path` existence assertions |
| B — writes to `output_dir` *and* `IMAGES_DIR` (existence assertions still pass) | **FAILED** — caught by the snapshot assertion alone |

Mutation B is the one that isolates the new guard, and it is why the snapshot records mtime. Measured on this box: regenerating `single_geohash.png` twice produces **identical bytes** (`dc9dac09…` both runs), while the committed file hashes `9c6e6851…`. So PNG regeneration is byte-deterministic for a given matplotlib version and merely differs from whatever version produced the committed bytes. A content-only guard would therefore catch a stray write *here* but silently pass on a machine whose matplotlib reproduces the committed bytes. Comparing mtime makes the guard catch any write regardless of version. The `tech_companies.html` content hash would still have caught it (Folium ids are random per run), but that is one file's luck, not an invariant.

Both mutations were reverted with `git checkout --` after the fix was committed, and the suite re-run green (150 passed) with a clean tree.