### PR TITLE
fix: accept uppercase and mixed-case geohashes in decode()/decode_exactly()

### DIFF
--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -116,7 +116,9 @@ def decode(geohash: str) -> LatLong:
     """Decode a geohash into a latitude and longitude.
 
     Args:
-        geohash (str): The geohash string to decode.
+        geohash (str): The geohash string to decode. Input is case-insensitive, matching
+            :func:`~pygeohash.types.is_valid_geohash` and :func:`~pygeohash.neighbor.get_adjacent`,
+            so ``"U4PRUYD"`` and ``"U4pruYd"`` decode identically to ``"u4pruyd"``.
 
     Returns:
         LatLong: A named tuple containing the latitude and longitude.
@@ -132,7 +134,7 @@ def decode(geohash: str) -> LatLong:
     # The C extension raises ValueError("Invalid character in geohash") for any
     # non-base32 character, so we let it do the per-character validation instead
     # of paying for a Python-level scan on every call.
-    return LatLong(*c_decode(geohash))
+    return LatLong(*c_decode(geohash.lower()))
 
 
 def decode_exactly(geohash: str) -> ExactLatLong:
@@ -142,7 +144,9 @@ def decode_exactly(geohash: str) -> ExactLatLong:
     function by including the error margins for both latitude and longitude.
 
     Args:
-        geohash (str): The geohash string to decode.
+        geohash (str): The geohash string to decode. Input is case-insensitive, matching
+            :func:`~pygeohash.types.is_valid_geohash` and :func:`~pygeohash.neighbor.get_adjacent`,
+            so ``"U4PRUYD"`` and ``"U4pruYd"`` decode identically to ``"u4pruyd"``.
 
     Returns:
         ExactLatLong: A named tuple containing the latitude, longitude, and their
@@ -157,7 +161,7 @@ def decode_exactly(geohash: str) -> ExactLatLong:
         raise ValueError("Geohash cannot be empty.")
 
     # See decode(): the C extension validates characters and raises on its own.
-    return ExactLatLong(*c_decode_exactly(geohash))
+    return ExactLatLong(*c_decode_exactly(geohash.lower()))
 
 
 __all__ = [

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -223,6 +223,51 @@ def test_decode_exactly_invalid_chars():
         pgh.decode_exactly("ezs42a")  # 'a' is invalid
 
 
+CASE_VARIANTS = ["U4PRUYD", "U4pruYd", "u4PRUYd"]
+
+
+@pytest.mark.parametrize("variant", CASE_VARIANTS)
+def test_decode_is_case_insensitive(variant):
+    """Uppercase and mixed-case input decodes exactly like the lowercase form."""
+    assert pgh.decode(variant) == pgh.decode("u4pruyd")
+    assert pgh.decode_exactly(variant) == pgh.decode_exactly("u4pruyd")
+
+
+def test_validate_then_decode():
+    """The validate-then-use contract holds: what assert_valid_geohash accepts, decode decodes."""
+    validated = pgh.assert_valid_geohash("U4PRUYD")
+    assert pgh.decode(validated) == pgh.decode("u4pruyd")
+
+
+@pytest.mark.parametrize("variant", CASE_VARIANTS)
+def test_downstream_consumers_accept_uppercase(variant):
+    """Consumers routed through decode/decode_exactly accept uppercase too."""
+    assert pgh.get_bounding_box(variant) == pgh.get_bounding_box("u4pruyd")
+
+    center = pgh.decode("u4pruyd")
+    assert pgh.is_point_in_geohash(center.latitude, center.longitude, variant) is True
+
+    assert pgh.geohash_haversine_distance(variant, "u4pruyf") == pgh.geohash_haversine_distance("u4pruyd", "u4pruyf")
+
+    uppercase_collection = [variant, "EZS42"]
+    lowercase_collection = ["u4pruyd", "ezs42"]
+    assert pgh.mean(uppercase_collection) == pgh.mean(lowercase_collection)
+    assert pgh.variance(uppercase_collection) == pgh.variance(lowercase_collection)
+    assert pgh.std(uppercase_collection) == pgh.std(lowercase_collection)
+    # northern/eastern return the selected input verbatim, so the uppercase form comes back as-is.
+    assert pgh.northern(uppercase_collection) == variant
+    assert pgh.eastern(uppercase_collection) == variant
+
+
+@pytest.mark.parametrize("bad", ["a1i", "A1I", "ezs42a", "EZS42A", "ezs!2", "EZS!2"])
+def test_decode_rejects_out_of_alphabet_in_either_case(bad):
+    """Case normalization does not widen the alphabet: 'a', 'i', 'l', 'o' and punctuation still raise."""
+    with pytest.raises(ValueError, match="Invalid character in geohash"):
+        pgh.decode(bad)
+    with pytest.raises(ValueError, match="Invalid character in geohash"):
+        pgh.decode_exactly(bad)
+
+
 def test_check_validity():
     with pytest.raises(ValueError):
         pgh.geohash_approximate_distance("shibu", "shiba", check_validity=True)


### PR DESCRIPTION
Closes #99

## What changed

`is_valid_geohash()` lowercases before checking characters, `get_adjacent()` normalizes with `source_hash = geohash.lower()`, and `geohash_approximate_distance(..., check_validity=True)` lowercases both arguments after validating — but `decode()`/`decode_exactly()` handed the raw string to the C extension, which rejects anything outside the lowercase base-32 alphabet. So a caller who followed the library's own validation contract got an exception:

```
>>> pgh.is_valid_geohash("U4PRUYD")
True
>>> pgh.decode("U4PRUYD")
ValueError: Invalid character in geohash
```

The fix is two characters of normalization in the wrappers — `c_decode(geohash.lower())` and `c_decode_exactly(geohash.lower())` — which repairs every downstream consumer at once, since `get_bounding_box`, `is_point_in_geohash`, `geohash_haversine_distance`, all of `stats` and all of `viz` route through these two functions. Nothing else changed: non-string and empty input raise with their existing messages, out-of-alphabet characters still raise the C extension's `ValueError`, and already-lowercase input is bit-identical.

The two docstrings gained an `Args` note rather than a `>>>` block, because `tests/test_doctests.py` asserts the total example count is exactly 21.

### One judgment call

`.lower()` is the same normalization the three existing call sites use, so decode now agrees with `is_valid_geohash` on *every* input it accepts. That includes exactly one non-ASCII character: U+212A KELVIN SIGN, whose `.lower()` is ASCII `k` (I enumerated all of Unicode to confirm it is the only one). `is_valid_geohash("K")` already returned `True`, so this closes a gap rather than opening one, and the safety intent of `test_decode_non_ascii` is preserved — the character is folded to ASCII before it ever reaches the C decoder's 128-entry table, so there is no out-of-bounds index. An ASCII-only normalization would have kept that one input raising at the cost of leaving decode and the validator disagreeing again. Genuinely multibyte input (`"café"`, `"日本語"`, `"ezs42\x80"`) is unaffected and still raises.

## Verification

All commands run from the worktree with `.venv/bin/python` (Python 3.12, `-e ".[dev,viz]"`).

| Gate | Result |
|---|---|
| `-m pytest` | **212 passed** (199 on master + 13 new) |
| `-m ruff format . --check` | 36 files already formatted |
| `-m ruff check .` | All checks passed |
| `-m mypy --python-version 3.12 pygeohash` | Success: no issues found in 13 source files |
| `sphinx -W --keep-going -b html source` | build succeeded (run because public docstrings changed) |

Acceptance criteria confirmed directly against the built extension — `decode`, `decode_exactly`, `get_bounding_box`, `is_point_in_geohash`, `geohash_haversine_distance`, `mean`/`std` and `plot_geohash` all return values for `"U4PRUYD"`/`"U4pruYd"` identical to the lowercase form; `"a1i"`, `"A1I"`, `"ezs42\x80"` and `"日本語"` still raise `Invalid character in geohash`; `123` and `""` still raise their original messages.

### Mutation test

With the fix committed, I reverted **only** the two `.lower()` calls (leaving the new tests in place) and re-ran — **7 failed, 44 passed** in `tests/test_geohash.py`:

- `test_decode_is_case_insensitive` (3 cases) — killed
- `test_validate_then_decode` — killed
- `test_downstream_consumers_accept_uppercase` (3 cases) — killed

To be precise about what each test earns: those 7 carry the behavior. The 6 cases in `test_decode_rejects_out_of_alphabet_in_either_case` pass on both the fixed and unfixed code — they document that case normalization does not widen the alphabet, and would catch a future over-broad "fix" that pre-filtered characters instead of normalizing them, but they do not guard this change. Restoring the file left the worktree clean (`git status --porcelain` empty) and the full suite green again.