### PR TITLE
Fix visualization extra imports

### DIFF
--- a/.github/workflows/viz-extra.yml
+++ b/.github/workflows/viz-extra.yml
@@ -1,0 +1,47 @@
+name: Test Visualization Extra
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  viz-only:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Install visualization extra only
+      run: |
+        uv venv
+        uv pip install -e ".[viz]"
+
+    - name: Exercise visualization API
+      run: |
+        .venv/bin/python - <<'PY'
+        import pygeohash as pgh
+        import pygeohash.viz as viz
+
+        figure, axis = viz.plot_geohash("u4pruyd")
+        assert figure is not None
+        assert axis is not None
+        assert viz.folium_map("u4pruyd") is not None
+        assert pgh.plot_geohash is viz.plot_geohash
+        assert pgh.plot_geohashes is viz.plot_geohashes
+        assert pgh.folium_map is viz.folium_map
+        PY

--- a/pygeohash/viz.py
+++ b/pygeohash/viz.py
@@ -13,18 +13,17 @@ Functions:
 # mypy: disable-error-code="list-item,assignment"
 
 import warnings
-from typing import List, Optional, Tuple, Union, Any, cast, TypeVar
-from typing_extensions import TypeAlias, Protocol
+from typing import List, Optional, Protocol, Tuple, Union, Any, cast, TypeVar
 
 from pygeohash.geohash import decode
 from pygeohash.bounding_box import get_bounding_box, geohashes_in_box, BoundingBox
 
 # Type aliases for better readability
-FoliumMap: TypeAlias = Any  # Would be folium.Map if folium was always available
-FoliumRectangle: TypeAlias = Any  # Would be folium.Rectangle if folium was always available
-FoliumElement: TypeAlias = Any  # Would be folium.Element if folium was always available
-MatplotlibAxis: TypeAlias = Any  # Would be matplotlib.axes.Axes if matplotlib was always available
-MatplotlibFigure: TypeAlias = Any  # Would be matplotlib.figure.Figure if matplotlib was always available
+FoliumMap = Any  # Would be folium.Map if folium was always available
+FoliumRectangle = Any  # Would be folium.Rectangle if folium was always available
+FoliumElement = Any  # Would be folium.Element if folium was always available
+MatplotlibAxis = Any  # Would be matplotlib.axes.Axes if matplotlib was always available
+MatplotlibFigure = Any  # Would be matplotlib.figure.Figure if matplotlib was always available
 BoundingBoxCoords = Tuple[float, float, float, float]  # min_lat, min_lon, max_lat, max_lon
 
 T = TypeVar("T")


### PR DESCRIPTION
Closes #98

## Summary

- remove the undeclared `typing_extensions` import from the visualization module
- use the standard-library `Protocol` and implicit type aliases supported across Python 3.8+
- add an isolated CI workflow that installs only `.[viz]` and exercises module and lazy package-root visualization APIs

## Verification

- `.venv/bin/python -m pytest` — 199 passed
- `.venv/bin/python -m ruff format . --check` — 36 files already formatted
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy --python-version 3.12 pygeohash` — success, 13 source files
- clean Python 3.12 venv: installed the local `.[viz]` extra from outside the source tree, confirmed `typing_extensions` was absent, created a figure/axis and Folium map, and resolved `pgh.plot_geohash`, `pgh.plot_geohashes`, and `pgh.folium_map`