### PR TITLE
fix: reject bare geohash strings in the collection statistics API

### DIFF
--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -234,6 +234,15 @@ The library provides type aliases for collections of geohashes:
         def calculate_center(geohashes: GeohashCollection) -> str:
             return mean(geohashes)
 
+    A single geohash string technically satisfies this type but iterates as one
+    geohash per character, so the statistics functions reject it with a
+    ``TypeError``. Wrap a single geohash in a collection:
+
+    .. code-block:: python
+
+        mean(["9q9hwg"])  # correct
+        mean("9q9hwg")  # raises TypeError
+
 ``GeohashList``
     A concrete list of geohash strings:
 

--- a/pygeohash/stats.py
+++ b/pygeohash/stats.py
@@ -27,6 +27,27 @@ T = TypeVar("T")
 _CIRCULAR_MEAN_TOLERANCE: Final[float] = 1e-12
 
 
+def _reject_bare_geohash_string(geohashes: GeohashCollection) -> None:
+    """Reject a single geohash string passed where a collection is expected.
+
+    A ``str`` satisfies ``Collection[str]``, so passing one geohash instead of a
+    collection of geohashes would otherwise be treated as a collection of
+    single-character geohashes and return a plausible but meaningless result.
+
+    Args:
+        geohashes (GeohashCollection): The value supplied by the caller.
+
+    Raises:
+        TypeError: If ``geohashes`` is a string rather than a collection of
+            geohash strings.
+    """
+    if isinstance(geohashes, str):
+        raise TypeError(
+            "geohashes must be a collection of geohash strings, not a single geohash string. "
+            f"Wrap a single geohash in a collection, for example [{geohashes!r}]."
+        )
+
+
 def _circular_mean_longitude(longitudes: Sequence[float]) -> float:
     """Calculate the circular mean of a sequence of longitudes in degrees.
 
@@ -84,13 +105,19 @@ def _max_cardinal(geohashes: GeohashCollection, key_func: Callable[[LatLong], fl
     """Find the extreme geohash in a collection based on a key function.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
         key_func (Callable[[LatLong], float]): Function to extract the value to compare.
         reverse (bool): Whether to find maximum (True) or minimum (False).
 
     Returns:
         str: The geohash at the extreme position.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
     """
+    _reject_bare_geohash_string(geohashes)
+
     logger.debug("Finding %s for %d geohashes", "maximum" if reverse else "minimum", len(geohashes))
 
     if not geohashes:
@@ -110,10 +137,14 @@ def northern(geohashes: GeohashCollection) -> str:
     """Find the northernmost geohash in a collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         str: The northernmost geohash.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> northern(["u4pruyd", "u4pruyf", "u4pruyc"])
@@ -129,10 +160,14 @@ def southern(geohashes: GeohashCollection) -> str:
     """Find the southernmost geohash in a collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         str: The southernmost geohash.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> southern(["u4pruyd", "u4pruyf", "u4pruyc"])
@@ -148,10 +183,14 @@ def eastern(geohashes: GeohashCollection) -> str:
     """Find the easternmost geohash in a collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         str: The easternmost geohash.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> eastern(["u4pruyd", "u4pruyf", "u4pruyc"])
@@ -167,10 +206,14 @@ def western(geohashes: GeohashCollection) -> str:
     """Find the westernmost geohash in a collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         str: The westernmost geohash.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> western(["u4pruyd", "u4pruyf", "u4pruyc"])
@@ -192,17 +235,23 @@ def mean(geohashes: GeohashCollection, precision: GeohashPrecision = 12) -> str:
     mean of the longitudes is used instead.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
         precision (GeohashPrecision, optional): The precision of the resulting geohash. Defaults to 12.
 
     Returns:
         str: A geohash representing the mean position, or an empty string for an
             empty collection.
 
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
+
     Example:
         >>> mean(["u4pruyd", "u4pruyf", "u4pruyc"])
         'u4pruyf1m6dt'
     """
+    _reject_bare_geohash_string(geohashes)
+
     logger.debug("Calculating mean position for %d geohashes with precision %d", len(geohashes), precision)
 
     if not geohashes:
@@ -226,15 +275,21 @@ def variance(geohashes: GeohashCollection) -> float:
     to each geohash in the collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         float: The variance in meters squared.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> round(variance(["u4pruyd", "u4pruyf", "u4pruyc"]), 1)
         6665.5
     """
+    _reject_bare_geohash_string(geohashes)
+
     logger.debug("Calculating variance for %d geohashes", len(geohashes))
 
     if not geohashes:
@@ -256,15 +311,21 @@ def std(geohashes: GeohashCollection) -> float:
     the average distance from the mean position to each geohash in the collection.
 
     Args:
-        geohashes (GeohashCollection): Collection of geohash strings.
+        geohashes (GeohashCollection): Collection of geohash strings. A single geohash
+            must be wrapped in a collection, for example ``["u4pruyd"]``.
 
     Returns:
         float: The standard deviation in meters.
+
+    Raises:
+        TypeError: If ``geohashes`` is a single geohash string.
 
     Example:
         >>> round(std(["u4pruyd", "u4pruyf", "u4pruyc"]), 1)
         81.6
     """
+    _reject_bare_geohash_string(geohashes)
+
     logger.debug("Calculating standard deviation for %d geohashes", len(geohashes))
     result = math.sqrt(variance(geohashes))
     logger.debug("Calculated standard deviation: %f meters", result)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -8,6 +8,19 @@ import pygeohash as pgh
 WEST_OF_LINE = pgh.encode(0.0, 179.0)
 EAST_OF_LINE = pgh.encode(0.0, -179.0)
 
+# Every public function that takes a collection of geohashes.
+COLLECTION_FUNCTIONS = [
+    pgh.northern,
+    pgh.southern,
+    pgh.eastern,
+    pgh.western,
+    pgh.mean,
+    pgh.variance,
+    pgh.std,
+]
+
+CLUSTER = ["u4pruyd", "u4pruyf", "u4pruyc"]
+
 
 def test_mean_across_antimeridian():
     """A collection straddling the antimeridian is centered near +/-180, not near Greenwich."""
@@ -106,3 +119,47 @@ def test_empty_collection():
     assert pgh.variance([]) == 0.0
     assert pgh.std([]) == 0.0
     assert not math.isnan(pgh.std([]))
+
+
+@pytest.mark.parametrize("function", COLLECTION_FUNCTIONS, ids=lambda function: function.__name__)
+def test_bare_geohash_string_is_rejected(function):
+    """A single geohash string is not a collection of geohashes, even though it iterates like one."""
+    with pytest.raises(TypeError, match="collection of geohash strings"):
+        function("u4pruyd")
+
+
+@pytest.mark.parametrize("wrap", [list, tuple, set], ids=["list", "tuple", "set"])
+def test_non_string_collections_are_unchanged(wrap):
+    """Collections of geohashes keep their results whatever container they arrive in."""
+    # Cardinal ties resolve in input order, and a set has none, so these cells are
+    # chosen to share neither a latitude nor a longitude.
+    north_east = pgh.encode(57.7, 10.5, 8)
+    middle = pgh.encode(57.6, 10.4, 8)
+    south_west = pgh.encode(57.5, 10.3, 8)
+    corners = wrap([middle, north_east, south_west])
+
+    assert pgh.northern(corners) == north_east
+    assert pgh.southern(corners) == south_west
+    assert pgh.eastern(corners) == north_east
+    assert pgh.western(corners) == south_west
+
+    assert pgh.mean(wrap(CLUSTER)) == "u4pruyf1m6dt"
+    assert pgh.variance(wrap(CLUSTER)) == pytest.approx(6665.5, abs=0.1)
+    assert pgh.std(wrap(CLUSTER)) == pytest.approx(81.6, abs=0.1)
+
+
+def test_single_element_collection_is_accepted():
+    """One geohash wrapped in a collection is the supported way to summarize a single cell."""
+    assert pgh.northern(["u4pruyd"]) == "u4pruyd"
+    assert pgh.southern(["u4pruyd"]) == "u4pruyd"
+    assert pgh.eastern(["u4pruyd"]) == "u4pruyd"
+    assert pgh.western(["u4pruyd"]) == "u4pruyd"
+    assert pgh.mean(["u4pruyd"], 7) == "u4pruyd"
+    assert pgh.variance(["u4pruyd"]) == pytest.approx(0.0, abs=1e-3)
+    assert pgh.std(["u4pruyd"]) == pytest.approx(0.0, abs=1e-1)
+
+
+@pytest.mark.parametrize("function", COLLECTION_FUNCTIONS, ids=lambda function: function.__name__)
+def test_empty_collection_is_still_accepted(function):
+    """The guard rejects strings only; an empty collection keeps its documented result."""
+    assert function([]) in ("", 0.0)


### PR DESCRIPTION
Closes #102

## Problem

`GeohashCollection` is `Collection[str]`, and a Python `str` satisfies that. Passing a single geohash instead of a collection therefore iterated its characters as precision-1 geohashes and returned plausible-looking garbage rather than raising. On `master`, for `"u4pruyd"`:

```
northern  -> 'u'
southern  -> '4'
eastern   -> 'p'
western   -> '4'
mean      -> 't39nf7qtxyfg'
variance  -> 105656985699832.47
std       -> 10278958.395665996
```

## Change

- `pygeohash/stats.py` gains one shared guard, `_reject_bare_geohash_string`, raising `TypeError` with an actionable message (`geohashes must be a collection of geohash strings, not a single geohash string. Wrap a single geohash in a collection, for example ['u4pruyd'].`).
- All seven public collection functions route through it: `northern`/`southern`/`eastern`/`western` via the shared `_max_cardinal` helper they already delegate to, and `mean`/`variance`/`std` directly, so each validates before any iteration.
- Docstrings gain a `Raises:` entry and note that a single geohash must be wrapped; `docs/source/types.rst` says the same next to the `GeohashCollection` alias.
- `tests/test_stats.py` gains 18 tests: a parametrized rejection test over the seven package-root functions, container-shape tests (list/tuple/set), a one-element collection test, and an empty-collection test per function.

No behavior changes for valid collection inputs, and no other collection API is touched.

## Verification

Run from a clean `.venv` (`uv venv --python 3.12`, `uv pip install -e ".[dev,viz]"` plus `docs/requirements.txt`):

- `python -m pytest` — **230 passed** (212 collected on `master`, so 18 new). The pre-existing `mean`/`variance`/`std` doctests (`u4pruyf1m6dt` / `6665.5` / `81.6`) and the antimeridian tests are unchanged.
- `python -m ruff format . --check` — 36 files already formatted.
- `python -m ruff check .` — All checks passed.
- `python -m mypy --python-version 3.12 pygeohash` — Success, no issues in 13 source files.
- `sphinx-build -W --keep-going -b html source build/html` (the `validate-docs` command) — build succeeded.

Mutation check: with the guard's condition forced false (fix otherwise intact), the 7 `test_bare_geohash_string_is_rejected` cases fail and the other 28 stats tests still pass — so the new rejection tests carry the behavior and the valid-input tests are not coupled to the guard. The fix was restored and the full suite re-run green.