### PR TITLE
fix: reject boolean coordinates and precision values

### DIFF
--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -45,12 +45,20 @@ def encode(latitude: float, longitude: float, precision: GeohashPrecision = 12) 
 
     Raises:
         ValueError: If the latitude or longitude values are invalid, or if the precision
-            is not an integer or is outside the valid range (1-12).
+            is not an integer or is outside the valid range (1-12). Booleans are
+            rejected for all three arguments, even though ``bool`` is a subclass of
+            ``int``.
     """
-    if not isinstance(precision, int):
+    # bool is a subclass of int, so it has to be rejected explicitly.
+    if isinstance(precision, bool) or not isinstance(precision, int):
         raise ValueError(f"Precision must be an integer, but got {type(precision).__name__}.")
     if not (MIN_PRECISION <= precision <= MAX_PRECISION):
         raise ValueError(f"Precision must be between {MIN_PRECISION} and {MAX_PRECISION}, but got {precision}.")
+
+    if isinstance(latitude, bool):
+        raise ValueError(f"Latitude must be a number, but got {type(latitude).__name__}.")
+    if isinstance(longitude, bool):
+        raise ValueError(f"Longitude must be a number, but got {type(longitude).__name__}.")
 
     # Validate latitude range
     if not (-90.0 <= latitude <= 90.0):
@@ -84,12 +92,20 @@ def encode_strictly(latitude: float, longitude: float, precision: GeohashPrecisi
 
     Raises:
         ValueError: If the latitude or longitude values are invalid, or if the precision
-            is not an integer or is outside the valid range (1-12).
+            is not an integer or is outside the valid range (1-12). Booleans are
+            rejected for all three arguments, even though ``bool`` is a subclass of
+            ``int``.
     """
-    if not isinstance(precision, int):
+    # bool is a subclass of int, so it has to be rejected explicitly.
+    if isinstance(precision, bool) or not isinstance(precision, int):
         raise ValueError(f"Precision must be an integer, but got {type(precision).__name__}.")
     if not (MIN_PRECISION <= precision <= MAX_PRECISION):
         raise ValueError(f"Precision must be between {MIN_PRECISION} and {MAX_PRECISION}, but got {precision}.")
+
+    if isinstance(latitude, bool):
+        raise ValueError(f"Latitude must be a number, but got {type(latitude).__name__}.")
+    if isinstance(longitude, bool):
+        raise ValueError(f"Longitude must be a number, but got {type(longitude).__name__}.")
 
     # Validate latitude range
     if not (-90.0 <= latitude <= 90.0):

--- a/pygeohash/types.py
+++ b/pygeohash/types.py
@@ -124,9 +124,10 @@ def is_valid_latitude(value: Union[float, int, object]) -> bool:
         value: Number to validate
 
     Returns:
-        bool: True if valid latitude, False otherwise
+        bool: True if valid latitude, False otherwise. Booleans are rejected even
+            though ``bool`` is a subclass of ``int``.
     """
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         return False
     return -90 <= float(value) <= 90
 
@@ -138,9 +139,10 @@ def is_valid_longitude(value: Union[float, int, object]) -> bool:
         value: Number to validate
 
     Returns:
-        bool: True if valid longitude, False otherwise
+        bool: True if valid longitude, False otherwise. Booleans are rejected even
+            though ``bool`` is a subclass of ``int``.
     """
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         return False
     return -180 <= float(value) <= 180
 

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -52,6 +52,37 @@ def test_encode_invalid_longitude():
         pgh.encode(0.0, 999.0)
 
 
+@pytest.mark.parametrize("encoder", [pgh.encode, pgh.encode_strictly])
+@pytest.mark.parametrize("value", [True, False])
+def test_encode_rejects_boolean_latitude(encoder, value):
+    """A bool must not be encoded as latitude 1.0/0.0 just because bool subclasses int."""
+    with pytest.raises(ValueError, match="Latitude must be a number"):
+        encoder(value, 0.0)
+
+
+@pytest.mark.parametrize("encoder", [pgh.encode, pgh.encode_strictly])
+@pytest.mark.parametrize("value", [True, False])
+def test_encode_rejects_boolean_longitude(encoder, value):
+    """A bool must not be encoded as longitude 1.0/0.0 just because bool subclasses int."""
+    with pytest.raises(ValueError, match="Longitude must be a number"):
+        encoder(0.0, value)
+
+
+@pytest.mark.parametrize("encoder", [pgh.encode, pgh.encode_strictly])
+@pytest.mark.parametrize("value", [True, False])
+def test_encode_rejects_boolean_precision(encoder, value):
+    """A bool precision must raise instead of silently meaning precision 1 (or 0)."""
+    with pytest.raises(ValueError, match="Precision must be an integer"):
+        encoder(42.6, -5.6, precision=value)
+
+
+@pytest.mark.parametrize("encoder", [pgh.encode, pgh.encode_strictly])
+def test_encode_accepts_integer_coordinates_and_precision(encoder):
+    """Rejecting bools must not disturb ordinary int coordinates or precisions."""
+    assert encoder(42, -5, 5) == encoder(42.0, -5.0, 5) == "ezkqy"
+    assert encoder(0, 0, 1) == "s"
+
+
 def test_encode_strictly():
     assert pgh.encode(0.0, -5.6, precision=5) == "ebh00"
     assert pgh.encode_strictly(0.0, -5.6, precision=5) == "ebh00"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,13 @@
 """Tests for type validation functions in pygeohash.types."""
 
 import pytest
-from pygeohash.types import is_valid_latitude, is_valid_longitude, is_valid_geohash
+from pygeohash.types import (
+    assert_valid_latitude,
+    assert_valid_longitude,
+    is_valid_geohash,
+    is_valid_latitude,
+    is_valid_longitude,
+)
 
 # Test cases for is_valid_latitude
 # Format: (latitude, expected_result)
@@ -15,8 +21,12 @@ valid_latitude_cases = [
     (-90.000001, False),  # Just below lower boundary
     (100.0, False),
     (-100.0, False),
+    (45, True),  # Plain integers stay valid
+    (-45, True),
     ("not a number", False),
     (None, False),
+    (True, False),  # bool is a subclass of int but is not a coordinate
+    (False, False),
 ]
 
 
@@ -74,8 +84,12 @@ valid_longitude_cases = [
     (-180.000001, False),  # Just below lower boundary
     (200.0, False),
     (-200.0, False),
+    (90, True),  # Plain integers stay valid
+    (-90, True),
     ("not a number", False),
     (None, False),
+    (True, False),  # bool is a subclass of int but is not a coordinate
+    (False, False),
 ]
 
 
@@ -83,6 +97,26 @@ valid_longitude_cases = [
 def test_is_valid_longitude(longitude, expected):
     """Test the is_valid_longitude function with various inputs."""
     assert is_valid_longitude(longitude) == expected
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_assert_valid_latitude_rejects_booleans(value):
+    """assert_valid_latitude must not silently convert a bool into 1.0/0.0."""
+    with pytest.raises(ValueError, match="Invalid latitude"):
+        assert_valid_latitude(value)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_assert_valid_longitude_rejects_booleans(value):
+    """assert_valid_longitude must not silently convert a bool into 1.0/0.0."""
+    with pytest.raises(ValueError, match="Invalid longitude"):
+        assert_valid_longitude(value)
+
+
+def test_assert_valid_coordinates_accept_integers():
+    """Ordinary integer coordinates keep working and come back as floats."""
+    assert assert_valid_latitude(45) == 45.0
+    assert assert_valid_longitude(-120) == -120.0
 
 
 # TODO: Add similar tests for is_valid_longitude and is_valid_geohash


### PR DESCRIPTION
Closes #96

Python's `bool` is a subclass of `int`, so every numeric check on the coordinate path admitted `True`/`False` and converted a type mistake into a plausible geographic value. Measured on master before the fix:

```
is_valid_latitude(True)        -> True
assert_valid_latitude(True)    -> 1.0
encode(True, False)            -> 's00j8n012j80'   # i.e. (1.0, 0.0)
encode(0, 0, precision=True)   -> 's'              # silently precision 1
```

## What changed

- `pygeohash/types.py` — `is_valid_latitude()` / `is_valid_longitude()` reject `bool` explicitly before the `isinstance(value, (int, float))` check, so `assert_valid_latitude()` / `assert_valid_longitude()` now raise `ValueError` for booleans too.
- `pygeohash/geohash.py` — `encode()` and `encode_strictly()` reject a `bool` precision (`Precision must be an integer, but got bool.`) and a `bool` latitude/longitude (`Latitude must be a number, but got bool.`).
- Ordinary integer coordinates and integer precisions are untouched: `encode(42, -5, 5) == encode(42.0, -5.0, 5) == "ezkqy"`.

Docstrings note the `bool`/`int` subclassing reason; no new `>>>` examples were added, so the doctest-count gate is unaffected.

Compatibility note: a caller deliberately passing `True`/`False` as 0/1 coordinates now gets a `ValueError` instead of a geohash. That is the point of the issue, and the coordinates it produced (1.0, 0.0) were almost certainly not what such a caller meant.

## Verification

Local, Python 3.12 venv built with `uv venv` + `uv pip install -e ".[dev,viz]"`; every gate run through `.venv/bin/python -m ...`.

- `pytest` — **257 passed** (230 on master before this branch; +27 new parametrized cases).
- `ruff format . --check` — 36 files already formatted.
- `ruff check .` — All checks passed.
- `mypy --python-version 3.12 pygeohash` — Success, no issues in 13 source files.
- `sphinx -W --keep-going -b html source` from `docs/` — build succeeded (public docstrings changed).
- `git status --porcelain` empty after a full suite run.

### Mutation testing

Each half of the fix was reverted separately (with `__pycache__` cleared and the mutation confirmed live in the interpreter, not just on disk), then the suite re-run:

| Mutation | Live behaviour | Result |
|---|---|---|
| Drop the `bool` guard in both `types.py` validators | `is_valid_latitude(True)` -> `True` | **8 failed** (4 parametrized validator cases + the 4 `assert_valid_*` tests) |
| Drop only the `bool` precision guard in `geohash.py` | `encode(0, 0, precision=True)` -> `'s'` | **4 failed** (`test_encode_rejects_boolean_precision`, both encoders) |
| Drop only the `bool` lat/lon guards in `geohash.py` | `encode(True, False)` -> `'s00j8n012j80'` | **8 failed** (boolean latitude + longitude, both encoders) |
| Over-broad "fix": reject *all* ints, not just `bool` | `is_valid_latitude(45)` -> `False` | **31 failed**, including the new int-acceptance tests |

The last row is the check that the new tests pin the intended behaviour rather than just "booleans raise" — deleting the numeric path entirely is caught too. All mutations were restored and the suite re-confirmed at 257 passed with a clean worktree.