### PR TITLE
Validate BoundingBox coordinates against world bounds

### DIFF
--- a/pygeohash/bounding_box.py
+++ b/pygeohash/bounding_box.py
@@ -7,6 +7,7 @@ related to geospatial regions.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Iterable, List, NamedTuple, Set, Iterator, Type, TypeVar
 
 from pygeohash.geohash import decode_exactly, encode
@@ -34,7 +35,8 @@ class BoundingBox(_BoundingBoxFields):
 
     The fields interleave latitude and longitude, so the order is
     ``(min_lat, min_lon, max_lat, max_lon)`` rather than the grouped
-    ``(min_lat, max_lat, min_lon, max_lon)``. Construction rejects an inverted box
+    ``(min_lat, max_lat, min_lon, max_lon)``. Coordinates must be finite and within
+    the geographic bounds for their axis. Construction also rejects an inverted box
     (``min_lat > max_lat`` or ``min_lon > max_lon``) with a ``ValueError``, which is
     what a grouped argument list produces. A degenerate box whose minimum equals its
     maximum on either axis is valid. Boxes spanning the antimeridian, which would need
@@ -42,19 +44,37 @@ class BoundingBox(_BoundingBoxFields):
 
     Attributes:
         min_lat (float): The minimum (southern) latitude of the box in decimal degrees.
-            Must not exceed ``max_lat``.
+            Must be between -90 and 90 and not exceed ``max_lat``.
         min_lon (float): The minimum (western) longitude of the box in decimal degrees.
-            Must not exceed ``max_lon``.
-        max_lat (float): The maximum (northern) latitude of the box in decimal degrees.
-        max_lon (float): The maximum (eastern) longitude of the box in decimal degrees.
+            Must be between -180 and 180 and not exceed ``max_lon``.
+        max_lat (float): The maximum (northern) latitude of the box in decimal degrees,
+            between -90 and 90.
+        max_lon (float): The maximum (eastern) longitude of the box in decimal degrees,
+            between -180 and 180.
 
     Raises:
-        ValueError: If ``min_lat > max_lat`` or ``min_lon > max_lon``.
+        ValueError: If a coordinate is non-finite, outside its geographic bounds, or
+            the box has ``min_lat > max_lat`` or ``min_lon > max_lon``.
     """
 
     __slots__ = ()
 
     def __new__(cls, min_lat: float, min_lon: float, max_lat: float, max_lon: float) -> "BoundingBox":
+        for field, value, lower, upper in (
+            ("min_lat", min_lat, -90.0, 90.0),
+            ("min_lon", min_lon, -180.0, 180.0),
+            ("max_lat", max_lat, -90.0, 90.0),
+            ("max_lon", max_lon, -180.0, 180.0),
+        ):
+            try:
+                is_finite = math.isfinite(value)
+            except TypeError:
+                is_finite = False
+            if not is_finite:
+                raise ValueError(f"{field} ({value}) must be a finite number")
+            if not lower <= value <= upper:
+                raise ValueError(f"{field} ({value}) must be between {lower:g} and {upper:g}")
+
         if min_lat > max_lat:
             raise ValueError(f"min_lat ({min_lat}) must not exceed max_lat ({max_lat}); {_FIELD_ORDER}")
         if min_lon > max_lon:

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -281,6 +281,42 @@ class TestBoundingBox:
 
         assert tuple(bbox) == fields
 
+    @pytest.mark.parametrize("field_index", range(4))
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_coordinate_is_rejected(self, field_index, value):
+        """Every bounding-box field requires a finite coordinate."""
+        fields = [10.0, 20.0, 30.0, 40.0]
+        fields[field_index] = value
+
+        with pytest.raises(ValueError, match="finite"):
+            BoundingBox(*fields)
+
+    @pytest.mark.parametrize(
+        ("fields", "field"),
+        [
+            ((-90.1, 20.0, 30.0, 40.0), "min_lat"),
+            ((10.0, -180.1, 30.0, 40.0), "min_lon"),
+            ((10.0, 20.0, 90.1, 40.0), "max_lat"),
+            ((10.0, 20.0, 30.0, 180.1), "max_lon"),
+        ],
+    )
+    def test_out_of_range_coordinate_is_rejected(self, fields, field):
+        """Each field is constrained to the geographic bounds for its axis."""
+        with pytest.raises(ValueError, match=field):
+            BoundingBox(*fields)
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            (-90.0, -180.0, 90.0, 180.0),
+            (-90.0, -180.0, -90.0, -180.0),
+            (90.0, 180.0, 90.0, 180.0),
+        ],
+    )
+    def test_world_boundaries_are_accepted(self, fields):
+        """Exact world limits, including degenerate corner boxes, remain valid."""
+        assert tuple(BoundingBox(*fields)) == fields
+
     @pytest.mark.parametrize("geohash", ["s", "ezs42", "u4pruyd", "u4pruydqqvj8"])
     def test_geohashes_in_box_on_degenerate_box_returns_containing_cell(self, geohash):
         """A zero-area box still enumerates the cell that contains it."""
@@ -301,6 +337,20 @@ class TestBoundingBox:
         assert bbox._replace(max_lat=35.0) == BoundingBox(10.0, 20.0, 35.0, 40.0)
         with pytest.raises(ValueError, match="min_lat"):
             bbox._replace(max_lat=5.0)
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda bbox: bbox._replace(max_lon=float("inf")),
+            lambda bbox: bbox._replace(max_lon=181.0),
+            lambda bbox: BoundingBox._make((10.0, 20.0, float("nan"), 40.0)),
+            lambda bbox: BoundingBox._make((10.0, -181.0, 30.0, 40.0)),
+        ],
+    )
+    def test_make_and_replace_validate_coordinates(self, operation):
+        """Named-tuple construction helpers cannot bypass coordinate validation."""
+        with pytest.raises(ValueError):
+            operation(BoundingBox(10.0, 20.0, 30.0, 40.0))
 
     @pytest.mark.parametrize("precision", range(1, 13))
     def test_get_bounding_box_output_is_always_constructible(self, precision):


### PR DESCRIPTION
Closes #97

## Summary

- reject non-finite bounding-box coordinates with field-specific `ValueError`s
- enforce latitude `[-90, 90]` and longitude `[-180, 180]` bounds before existing ordering checks
- cover direct construction, exact world boundaries, degenerate boxes, `_make`, and `_replace`

## Verification

- `.venv/bin/python -m pytest` — 280 passed
- `.venv/bin/python -m ruff format . --check` — 36 files already formatted
- `.venv/bin/python -m ruff check .` — passed
- `.venv/bin/python -m mypy --python-version 3.12 pygeohash` — no issues in 13 source files
- `.venv/bin/python -m sphinx -W --keep-going -b html docs/source /tmp/pygeohash-97-docs` — succeeded
- mutation check: removing the new validation caused 20 focused failures; restoring it returned `tests/test_bounding_box.py` to 75 passed