### PR TITLE
Reject over-precision geohashes when decoding

### DIFF
--- a/pygeohash/cgeohash/geohash_module.c
+++ b/pygeohash/cgeohash/geohash_module.c
@@ -112,6 +112,11 @@ static int decode_to_doubles(const char *geohash, double *out_lat, double *out_l
     int is_even = 1;
     size_t len = strlen(geohash);
 
+    if (len < 1 || len > 12) {
+        PyErr_SetString(PyExc_ValueError, "Geohash must be between 1 and 12 characters long");
+        return -1;
+    }
+
     init_base32_decode_map();
 
     for (size_t i = 0; i < len; i++) {

--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -140,12 +140,15 @@ def decode(geohash: str) -> LatLong:
         LatLong: A named tuple containing the latitude and longitude.
 
     Raises:
-        ValueError: If the geohash is not a string, is empty, or contains invalid characters.
+        ValueError: If the geohash is not a string, is not between 1 and 12 characters,
+            or contains invalid characters.
     """
     if not isinstance(geohash, str):
         raise ValueError(f"Geohash must be a string, but got {type(geohash).__name__}.")
     if not geohash:
         raise ValueError("Geohash cannot be empty.")
+    if len(geohash) > MAX_PRECISION:
+        raise ValueError(f"Geohash must be at most {MAX_PRECISION} characters long.")
 
     # The C extension raises ValueError("Invalid character in geohash") for any
     # non-base32 character, so we let it do the per-character validation instead
@@ -169,12 +172,15 @@ def decode_exactly(geohash: str) -> ExactLatLong:
             respective error margins.
 
     Raises:
-        ValueError: If the geohash is not a string, is empty, or contains invalid characters.
+        ValueError: If the geohash is not a string, is not between 1 and 12 characters,
+            or contains invalid characters.
     """
     if not isinstance(geohash, str):
         raise ValueError(f"Geohash must be a string, but got {type(geohash).__name__}.")
     if not geohash:
         raise ValueError("Geohash cannot be empty.")
+    if len(geohash) > MAX_PRECISION:
+        raise ValueError(f"Geohash must be at most {MAX_PRECISION} characters long.")
 
     # See decode(): the C extension validates characters and raises on its own.
     return ExactLatLong(*c_decode_exactly(geohash.lower()))

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -1,5 +1,6 @@
 import pytest
 import pygeohash as pgh
+from pygeohash.cgeohash import geohash_module
 
 __author__ = "willmcginnis"
 
@@ -252,6 +253,61 @@ def test_decode_exactly_invalid_chars():
     """Test decode_exactly with invalid characters."""
     with pytest.raises(ValueError, match="Invalid character in geohash"):
         pgh.decode_exactly("ezs42a")  # 'a' is invalid
+
+
+DECODE_APIS = [
+    pytest.param(pgh.decode, id="public-decode"),
+    pytest.param(pgh.decode_exactly, id="public-decode-exactly"),
+    pytest.param(geohash_module.decode, id="native-decode"),
+    pytest.param(geohash_module.decode_exactly, id="native-decode-exactly"),
+]
+EXACT_DECODERS = (pgh.decode_exactly, geohash_module.decode_exactly)
+BOUNDARY_DECODE_RESULTS = {
+    "u": ((67.5, 22.5), (67.5, 22.5, 22.5, 22.5)),
+    "u4pruydqqvj8": (
+        (57.64911004342139, 10.407439861446619),
+        (57.64911004342139, 10.407439861446619, 8.381903171539307e-08, 1.6763806343078613e-07),
+    ),
+}
+
+
+@pytest.mark.parametrize("decoder", DECODE_APIS)
+@pytest.mark.parametrize(
+    "geohash", [pytest.param("u" * 13, id="length-13"), pytest.param("u" * 1000, id="length-1000")]
+)
+def test_decode_rejects_over_precision_geohashes(decoder, geohash):
+    """Both public and native decode boundaries reject non-canonical lengths."""
+    with pytest.raises(ValueError, match="at most 12|between 1 and 12"):
+        decoder(geohash)
+
+
+@pytest.mark.parametrize(
+    "decoder,native_name",
+    [(pgh.decode, "c_decode"), (pgh.decode_exactly, "c_decode_exactly")],
+)
+def test_public_decode_rejects_over_precision_before_native_delegation(monkeypatch, decoder, native_name):
+    """The public boundary validates length without relying on the native layer."""
+    monkeypatch.setattr(f"pygeohash.geohash.{native_name}", lambda _geohash: pytest.fail("native decoder called"))
+
+    with pytest.raises(ValueError, match="at most 12"):
+        decoder("u" * 13)
+
+
+@pytest.mark.parametrize("decoder", DECODE_APIS)
+@pytest.mark.parametrize("geohash", ["u", "u4pruydqqvj8"])
+def test_decode_accepts_boundary_lengths(decoder, geohash):
+    """Canonical minimum and maximum precision geohashes remain decodable."""
+    expected = BOUNDARY_DECODE_RESULTS[geohash][decoder in EXACT_DECODERS]
+    assert decoder(geohash) == expected
+
+
+@pytest.mark.parametrize("decoder", [geohash_module.decode, geohash_module.decode_exactly])
+def test_native_decode_rejects_empty_and_invalid_geohashes(decoder):
+    """The native boundary enforces minimum length and retains character validation."""
+    with pytest.raises(ValueError, match="between 1 and 12"):
+        decoder("")
+    with pytest.raises(ValueError, match="Invalid character in geohash"):
+        decoder("ezs42a")
 
 
 CASE_VARIANTS = ["U4PRUYD", "U4pruYd", "u4PRUYd"]


### PR DESCRIPTION
Closes #95

## Summary

- reject geohashes longer than 12 characters in the public `decode` and `decode_exactly` wrappers
- enforce the canonical 1–12-character range in the shared native decode core, covering direct C-extension calls
- cover 13- and 1000-character inputs, exact results at lengths 1 and 12, and unchanged empty/invalid-character behavior across both APIs

## Verification

- `.venv/bin/python -m pytest` — 300 passed
- `.venv/bin/python -m ruff format . --check` — 36 files already formatted
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy --python-version 3.12 pygeohash` — success, 13 source files
- mutation check: removing only the Python length guards failed both pre-delegation regression cases
- mutation check: weakening only the native maximum failed all four direct-extension length 13/1000 cases
