### PR TITLE
fix: clamp generated Folium grid viewport to world bounds

### DIFF
--- a/pygeohash/viz.py
+++ b/pygeohash/viz.py
@@ -444,17 +444,24 @@ def add_geohash_grid(
     fill_opacity: float = 0.2,
     weight: int = 1,
 ) -> FoliumMapProtocol:
-    """Add a grid of geohashes at the specified precision."""
+    """Add a grid of geohashes at the specified precision.
+
+    When no ``bbox`` is given the viewport is derived from the map center and zoom
+    and clipped to the world bounds, so maps centered near a pole or the
+    antimeridian render the visible part of the grid. An explicitly supplied
+    ``bbox`` is passed through unchanged and validated by :class:`BoundingBox`.
+    """
     # If no bounding box is provided, use the current map bounds
     if bbox is None:
         lat, lon = self.location
         # Rough estimate of degrees visible at different zoom levels
         degrees_visible = 360 / (2 ** (self._zoom_start - 1))
+        half_extent = degrees_visible / 2
         bbox = (
-            lat - degrees_visible / 2,  # min_lat
-            lon - degrees_visible / 2,  # min_lon
-            lat + degrees_visible / 2,  # max_lat
-            lon + degrees_visible / 2,  # max_lon
+            max(-90.0, lat - half_extent),  # min_lat
+            max(-180.0, lon - half_extent),  # min_lon
+            min(90.0, lat + half_extent),  # max_lat
+            min(180.0, lon + half_extent),  # max_lon
         )
 
     # Get all geohashes in the bounding box

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -200,5 +200,78 @@ class TestViz(unittest.TestCase):
             self.assertIsNone(m)
 
 
+# (center, attribute of the world edge the clipped grid should reach, its value)
+GRID_EDGE_CASES = [
+    ((89.9, 0.0), "max_lat", 90.0),
+    ((-89.9, 0.0), "min_lat", -90.0),
+    ((0.0, 179.9), "max_lon", 180.0),
+    ((0.0, -179.9), "min_lon", -180.0),
+]
+
+INVALID_GRID_BOXES = [
+    (-100.0, -10.0, -95.0, 10.0),
+    (-10.0, -200.0, 10.0, -190.0),
+    (50.0, 179.0, 51.0, -179.0),
+]
+
+
+def _grid_rectangle_bounds(folium_module, geohash_map):
+    """Collect ``(min_lat, min_lon, max_lat, max_lon)`` for every rectangle on the map."""
+    return [
+        (child.locations[0][0], child.locations[0][1], child.locations[1][0], child.locations[1][1])
+        for child in geohash_map._children.values()
+        if isinstance(child, folium_module.Rectangle)
+    ]
+
+
+@pytest.mark.parametrize("center, edge, edge_value", GRID_EDGE_CASES)
+def test_add_geohash_grid_clips_generated_viewport(center, edge, edge_value):
+    """A viewport derived near a world edge is clipped instead of raising."""
+    folium = pytest.importorskip("folium")
+    from pygeohash.viz import folium_map
+
+    geohash_map = folium_map(center=center, zoom_start=3)
+    geohash_map.add_geohash_grid(precision=2)
+
+    bounds = _grid_rectangle_bounds(folium, geohash_map)
+    assert len(bounds) > 0
+    assert all(-90.0 <= min_lat <= max_lat <= 90.0 for min_lat, _, max_lat, _ in bounds)
+    assert all(-180.0 <= min_lon <= max_lon <= 180.0 for _, min_lon, _, max_lon in bounds)
+
+    reached = {
+        "min_lat": min(bound[0] for bound in bounds),
+        "min_lon": min(bound[1] for bound in bounds),
+        "max_lat": max(bound[2] for bound in bounds),
+        "max_lon": max(bound[3] for bound in bounds),
+    }
+    assert reached[edge] == edge_value
+
+
+def test_add_geohash_grid_ordinary_viewport():
+    """An ordinary central viewport still adds geohash rectangles."""
+    folium = pytest.importorskip("folium")
+    from pygeohash.viz import folium_map
+
+    geohash_map = folium_map(center=(37.7749, -122.4194), zoom_start=3)
+    geohash_map.add_geohash_grid(precision=2)
+
+    bounds = _grid_rectangle_bounds(folium, geohash_map)
+    assert len(bounds) > 0
+    assert any(min_lat <= 37.7749 <= max_lat for min_lat, _, max_lat, _ in bounds)
+    assert any(min_lon <= -122.4194 <= max_lon for _, min_lon, _, max_lon in bounds)
+
+
+@pytest.mark.parametrize("bbox", INVALID_GRID_BOXES)
+def test_add_geohash_grid_rejects_explicit_invalid_bbox(bbox):
+    """An explicit caller-supplied box is still validated by BoundingBox."""
+    pytest.importorskip("folium")
+    from pygeohash.viz import folium_map
+
+    geohash_map = folium_map(center=(0.0, 0.0), zoom_start=3)
+
+    with pytest.raises(ValueError):
+        geohash_map.add_geohash_grid(precision=2, bbox=bbox)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #113

## What changed

`add_geohash_grid` derived its default viewport from the map center and zoom and handed the raw coordinates to `BoundingBox`. Near a pole or the antimeridian that box extends past the geographic domain, so the helper raised `ValueError` before adding anything:

```
pgh.folium_map(center=(89.9, 0), zoom_start=3).add_geohash_grid(precision=2)
# ValueError: max_lat (134.9) must be between -90 and 90
```

The generated extents are now clipped to `[-90, 90]` / `[-180, 180]`. Only the library-generated default is normalized — an explicit caller-supplied `bbox` is still passed through verbatim and validated by `BoundingBox`, so out-of-range and antimeridian-spanning boxes keep raising. The clipped grid omits the wrapped sliver on the far side of the antimeridian, consistent with the library's lack of antimeridian-spanning `BoundingBox` support.

Tests use a real Folium map and assert on the rectangles actually added to it (count, world-bounded coordinates, and that the grid reaches the clipped world edge), not merely that no exception was raised.

## Verification

Run against Folium 0.20.0 / Python 3.12.

- `pytest` — 308 passed (8 new).
- `ruff format . --check` — 36 files already formatted; `ruff check .` — clean; `mypy pygeohash` — no issues in 13 source files.
- Isolated `[viz]`-only venv (no `dev` extra), importing from outside the source tree: `plot_geohash`/`folium_map` work and all five grid centers add rectangles — `(89.9, 0)` → 90, `(-89.9, 0)` → 90, `(0, 179.9)` → 90, `(0, -179.9)` → 90, `(0, 0)` → 180.
- `sphinx-build -W --keep-going` — build succeeded.
- Mutation-tested both halves separately, with the mutation confirmed live in the interpreter each time:
  - reverting the clamp → the 4 near-edge cases fail (`ValueError`), the control and the explicit-bbox cases still pass;
  - the plausible over-broad fix (clamping the merged `bbox` so caller-supplied values are normalized too) → the two out-of-range explicit-bbox cases fail, everything else passes. The antimeridian-spanning explicit box survives that mutation — it documents the ordering rule rather than guarding this change.
  - Restored afterwards and re-ran the full suite: 308 passed.