### PR TITLE
Audit installed dependencies in security CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,7 +59,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          # The audit below covers every distribution installed in this
+          # environment, including the setuptools/wheel that ship preinstalled
+          # with the runner's Python and routinely lag behind published security
+          # fixes, so upgrade the build tooling along with pip.
+          python -m pip install --upgrade pip setuptools wheel
           pip install pip-audit
           pip install -e ".[dev,viz]"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,7 +65,20 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          pip-audit --path .
+          python - <<'PY'
+          from importlib.metadata import distributions
+
+          installed = sorted(
+              distribution.metadata["Name"]
+              for distribution in distributions()
+              if distribution.metadata["Name"].lower() != "pygeohash"
+          )
+          print(f"Found {len(installed)} installed third-party distributions:")
+          print("\n".join(installed))
+          if not installed:
+              raise SystemExit("No third-party distributions found to audit")
+          PY
+          pip-audit --verbose
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4 


### PR DESCRIPTION
Closes #111

## Summary

- audit the Python environment populated by the dependency install instead of restricting pip-audit to the repository path
- assert that at least one third-party distribution is installed before auditing
- enable verbose audit output so the job log identifies every distribution pip-audit checks
- retain dependency review as the pull-request dependency-diff gate

## Verification

- Parsed `.github/workflows/security.yml` with Ruby YAML.
- Ran the workflow install, distribution assertion, and `pip-audit --verbose` in a clean Python 3.11 environment: 109 third-party distributions were found, each audited package was logged, and no known vulnerabilities were found.
- Installed a known-vulnerable dependency set in a separate clean environment and ran pip-audit: 23 findings were reported and pip-audit exited with status 1.
- Ran `git diff --check` successfully.
