### PR TITLE
ci: smoke-test built distributions before publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,6 +31,11 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"  # Build for Intel and Apple Silicon on macOS
           CIBW_ARCHS_LINUX: native  # Build each Linux architecture on its native runner
       
+      # Fail the job before upload if a wheel built here cannot be installed and
+      # used, e.g. because it is missing the package or the compiled extension.
+      - name: Smoke-test a wheel built on this runner
+        run: python scripts/smoke_test_distribution.py --wheelhouse wheelhouse
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}
@@ -82,6 +87,11 @@ jobs:
           mkdir -p wheelhouse
           cp dist/*.tar.gz wheelhouse/
       
+      # Fail the job before upload if the tarball cannot be installed from source
+      # and used, e.g. because it is missing the package or the extension source.
+      - name: Smoke-test the built sdist
+        run: python scripts/smoke_test_distribution.py --sdist "$(ls dist/*.tar.gz)"
+
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/scripts/smoke_test_distribution.py
+++ b/scripts/smoke_test_distribution.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+"""Smoke-test a built pygeohash distribution before it is published.
+
+The script installs a built artifact into a throwaway virtual environment and
+then re-runs itself with that environment's interpreter from a directory outside
+the source checkout, so the probe cannot import the working tree. It exits
+non-zero when the distribution is missing the ``pygeohash`` package, missing the
+compiled ``pygeohash.cgeohash.geohash_module`` extension, or fails to reproduce
+known encode/decode values.
+
+Usage:
+    python scripts/smoke_test_distribution.py --wheelhouse wheelhouse
+    python scripts/smoke_test_distribution.py --sdist dist/pygeohash-3.4.0.tar.gz
+"""
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import venv
+
+SOURCE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Known values, independent of the installed build. A distribution missing the
+# package or its compiled extension fails before ever reaching them.
+KNOWN_LATITUDE = 42.6
+KNOWN_LONGITUDE = -5.6
+KNOWN_GEOHASH = "ezs42"
+KNOWN_CENTER = (42.60498046875, -5.60302734375)
+KNOWN_ERRORS = (0.02197265625, 0.02197265625)
+BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+
+
+def check(condition, message):
+    """Raise ``SystemExit`` with ``message`` when ``condition`` is falsy."""
+    if not condition:
+        raise SystemExit("distribution smoke test failed: {}".format(message))
+
+
+def parse_args(argv):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--wheelhouse", help="Directory holding wheels built for this platform.")
+    group.add_argument("--sdist", help="Path to the built source distribution tarball.")
+    group.add_argument(
+        "--verify",
+        action="store_true",
+        help="Internal: probe the pygeohash already installed for this interpreter.",
+    )
+    parser.add_argument(
+        "--source-root",
+        default=str(SOURCE_ROOT),
+        help="Path to the source checkout the distribution was built from.",
+    )
+    return parser.parse_args(argv)
+
+
+def venv_python(env_dir):
+    """Return the interpreter path of a virtual environment created at ``env_dir``."""
+    if os.name == "nt":
+        return env_dir / "Scripts" / "python.exe"
+    return env_dir / "bin" / "python"
+
+
+def install_command(python, args):
+    """Build the pip command that installs the requested artifact."""
+    command = [str(python), "-m", "pip", "install", "--no-cache-dir"]
+    if args.wheelhouse:
+        # --no-index/--only-binary force the install to resolve to a wheel from
+        # this build; pip selects the one matching this platform and interpreter.
+        command += ["--no-index", "--only-binary", ":all:", "--find-links", args.wheelhouse, "pygeohash"]
+    else:
+        # Installing the tarball directly builds this package from source, which
+        # is what consumers without a matching wheel get.
+        command += [args.sdist]
+    return command
+
+
+def install_and_probe(args):
+    """Install the artifact into a clean environment and probe it from outside the checkout."""
+    work_dir = pathlib.Path(tempfile.mkdtemp(prefix="pygeohash-smoke-"))
+    try:
+        env_dir = work_dir / "venv"
+        # symlinks matches what ``python -m venv`` defaults to per platform;
+        # copying the interpreter breaks relocated builds.
+        venv.EnvBuilder(with_pip=True, symlinks=os.name != "nt").create(str(env_dir))
+        python = venv_python(env_dir)
+
+        subprocess.run(install_command(python, args), check=True)  # noqa: S603
+        # The probe runs with the temporary directory as its working directory so
+        # a bare ``import pygeohash`` cannot resolve to the source checkout.
+        subprocess.run(  # noqa: S603
+            [str(python), str(pathlib.Path(__file__).resolve()), "--verify", "--source-root", args.source_root],
+            check=True,
+            cwd=str(work_dir),
+        )
+    finally:
+        shutil.rmtree(str(work_dir), ignore_errors=True)
+    return 0
+
+
+def check_outside_source_tree(module, source_root):
+    """Fail when the imported module is unfiled or resolves into the source checkout."""
+    module_file = getattr(module, "__file__", None)
+    check(
+        module_file is not None,
+        "{} has no file on disk; the distribution installed it as an empty namespace package".format(module.__name__),
+    )
+    module_dir = pathlib.Path(module_file).resolve().parent
+    source_root = pathlib.Path(source_root).resolve()
+    check(
+        source_root != module_dir and source_root not in module_dir.parents,
+        "imported {} from the source checkout ({}), not the installed distribution".format(module.__name__, module_dir),
+    )
+    return module_dir
+
+
+def verify(source_root):
+    """Import the installed distribution and assert known encode/decode values."""
+    import pygeohash as pgh
+    from pygeohash.cgeohash import geohash_module
+
+    package_dir = check_outside_source_tree(pgh, source_root)
+    check_outside_source_tree(geohash_module, source_root)
+
+    check(
+        not str(geohash_module.__file__).endswith(".py"),
+        "pygeohash.cgeohash.geohash_module is not a compiled extension ({})".format(geohash_module.__file__),
+    )
+    check(geohash_module.get_base32() == BASE32, "compiled extension returned an unexpected base32 alphabet")
+
+    encoded = pgh.encode(KNOWN_LATITUDE, KNOWN_LONGITUDE, precision=len(KNOWN_GEOHASH))
+    check(encoded == KNOWN_GEOHASH, "encode returned {!r}, expected {!r}".format(encoded, KNOWN_GEOHASH))
+
+    native_encoded = geohash_module.encode(KNOWN_LATITUDE, KNOWN_LONGITUDE, precision=len(KNOWN_GEOHASH))
+    check(
+        native_encoded == KNOWN_GEOHASH,
+        "compiled extension encode returned {!r}, expected {!r}".format(native_encoded, KNOWN_GEOHASH),
+    )
+
+    decoded = pgh.decode(KNOWN_GEOHASH)
+    check(
+        (decoded.latitude, decoded.longitude) == KNOWN_CENTER,
+        "decode returned {!r}, expected {!r}".format(tuple(decoded), KNOWN_CENTER),
+    )
+
+    exact = pgh.decode_exactly(KNOWN_GEOHASH)
+    check(
+        (exact.latitude_error, exact.longitude_error) == KNOWN_ERRORS,
+        "decode_exactly returned errors {!r}, expected {!r}".format(
+            (exact.latitude_error, exact.longitude_error), KNOWN_ERRORS
+        ),
+    )
+
+    from importlib.metadata import version
+
+    print("pygeohash {} smoke test passed from {}".format(version("pygeohash"), package_dir))
+    return 0
+
+
+def main(argv=None):
+    """Install the requested artifact and probe it, or probe an already installed one."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.verify:
+        return verify(args.source_root)
+    return install_and_probe(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #110

## What changed

`publish-pypi.yml` built wheels and an sdist and uploaded every artifact without ever installing one. A successful build is not proof that a distribution contains a usable `pygeohash` package and a working compiled `pygeohash.cgeohash.geohash_module` — the test suite runs elsewhere against an editable checkout, so a packaging regression could reach the publish job with every step green.

- **`scripts/smoke_test_distribution.py`** (new). Installs a built artifact into a throwaway virtual environment, then re-runs itself with that environment's interpreter from a temporary directory outside the checkout. The probe imports `pygeohash` and `pygeohash.cgeohash.geohash_module`, fails if either resolves back into the source tree or has no file on disk, fails if the extension is not a compiled module, and asserts known values: `encode(42.6, -5.6, precision=5) == "ezs42"` through both the package API and the extension, `decode("ezs42") == (42.60498046875, -5.60302734375)`, the `decode_exactly` error margins, and the extension's base32 alphabet.
- **`publish-pypi.yml`**: one step added to each build job, before its `upload-artifact` step. The wheel jobs run `--wheelhouse wheelhouse` (installed with `--no-index --only-binary :all:`, so the install must resolve to a wheel that job just built, and pip picks the one matching that runner and interpreter). The sdist job runs `--sdist dist/*.tar.gz`, which builds this package from source in the clean environment.

The driver does the venv creation, install and out-of-tree re-exec in Python rather than shell so the same one-line step works unchanged on the Linux, macOS and Windows wheel runners. No packaging configuration was changed — the new check found no defect in the current artifacts.

## Verification

Ran locally on macOS/arm64 with CPython 3.12, building real artifacts with `uv build`:

- Both modes pass against the current packaging: `--wheelhouse dist` and `--sdist dist/pygeohash-3.4.0.tar.gz` each install into a fresh venv and print `pygeohash 3.4.0 smoke test passed from …/venv/lib/python3.12/site-packages/pygeohash` (exit 0). The printed path confirms the probe imported the installed distribution, not the working tree.
- Mutation-tested against genuinely broken distributions, rebuilding artifacts for each:
  - `setup.py` with `ext_modules` dropped (wheel and sdist ship no compiled extension) — **caught**, both modes exit 1 on `ModuleNotFoundError: No module named 'pygeohash.cgeohash.geohash_module'`.
  - `[tool.setuptools] packages` reduced to `["pygeohash.cgeohash"]` (distribution ships the extension but none of the Python package) — **caught**, both modes exit 1 with `distribution smoke test failed: pygeohash has no file on disk; the distribution installed it as an empty namespace package`. Note `pip`/`uv pip` install this wheel successfully and exit 0; only importing from outside the checkout catches it.
  - Restored control re-run: both modes exit 0 again.
  - A third mutation (`packages = ["pygeohash"]`, dropping the `cgeohash` entry) correctly still passes — `build_ext` places the extension there regardless and the implicit namespace package works, so the artifact is genuinely usable. Recorded here so the pass is not read as a gap.
- Also verified the out-of-tree guard directly: `check_outside_source_tree` rejects a package directory equal to, or nested under, the given source root and accepts an unrelated one.
- Repo gates on the diff: `ruff format . --check` (37 files already formatted) and `ruff check .` (all checks passed) with ruff 0.16.2. No package code changed, so `pytest`/`mypy` behaviour is unaffected.

The release workflow itself only runs on a `v*` tag, so these steps are first exercised in CI at the next release.

## Note on macOS coverage

The macOS job builds both `x86_64` and `arm64` wheels; the runner is arm64, so pip installs and exercises the arm64 wheel. The x86_64 wheels are built by the same configuration but cannot be executed on that runner, so they are not individually probed. This satisfies the issue's "at least one wheel built by that job" criterion; cross-arch execution would need emulation and was left out of scope.