### PR TITLE
Reject booleans in the direct C encoder API

### DIFF
--- a/pygeohash/cgeohash/geohash_module.c
+++ b/pygeohash/cgeohash/geohash_module.c
@@ -24,6 +24,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 
@@ -195,6 +196,45 @@ static PyObject* geohash_decode(PyObject *self, PyObject *args) {
     return make_named_tuple(LatLong_type, Py_BuildValue("dd", lat, lon));
 }
 
+// Argument converters for the encoders. bool is a subclass of int, so the plain
+// "d"/"i" format units coerce True/False to 1.0/0.0 before any check below can
+// see them; these reject booleans up front so a direct extension call matches
+// the package-root wrappers' contract.
+static int convert_coordinate(PyObject *obj, void *addr) {
+    if (PyBool_Check(obj)) {
+        PyErr_SetString(PyExc_ValueError, "latitude and longitude must be numbers, not booleans");
+        return 0;
+    }
+    double value = PyFloat_AsDouble(obj);
+    if (value == -1.0 && PyErr_Occurred()) {
+        return 0;
+    }
+    *(double *)addr = value;
+    return 1;
+}
+
+static int convert_precision(PyObject *obj, void *addr) {
+    if (PyBool_Check(obj)) {
+        PyErr_SetString(PyExc_ValueError, "precision must be an integer, not a boolean");
+        return 0;
+    }
+    PyObject *index = PyNumber_Index(obj);
+    if (index == NULL) {
+        return 0;
+    }
+    long value = PyLong_AsLong(index);
+    Py_DECREF(index);
+    if (value == -1 && PyErr_Occurred()) {
+        return 0;
+    }
+    if (value < INT_MIN || value > INT_MAX) {
+        PyErr_SetString(PyExc_OverflowError, "Python int too large to convert to C int");
+        return 0;
+    }
+    *(int *)addr = (int)value;
+    return 1;
+}
+
 // Encode coordinates to a geohash string
 static PyObject* geohash_encode(PyObject *self, PyObject *args, PyObject *kwargs) {
     double latitude, longitude;
@@ -202,8 +242,10 @@ static PyObject* geohash_encode(PyObject *self, PyObject *args, PyObject *kwargs
 
     static char *kwlist[] = {"latitude", "longitude", "precision", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "dd|i", kwlist,
-                                    &latitude, &longitude, &precision)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&O&|O&", kwlist,
+                                    convert_coordinate, &latitude,
+                                    convert_coordinate, &longitude,
+                                    convert_precision, &precision)) {
         return NULL;
     }
 
@@ -282,8 +324,10 @@ static PyObject* geohash_encode_strictly(PyObject *self, PyObject *args, PyObjec
 
     static char *kwlist[] = {"latitude", "longitude", "precision", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "dd|i", kwlist,
-                                    &latitude, &longitude, &precision)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&O&|O&", kwlist,
+                                    convert_coordinate, &latitude,
+                                    convert_coordinate, &longitude,
+                                    convert_precision, &precision)) {
         return NULL;
     }
 

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -157,6 +157,50 @@ def test_c_encode_rejects_non_finite_coordinates():
                 c_func(latitude, longitude)
 
 
+def test_c_encode_rejects_boolean_coordinates():
+    """bool is a subclass of int, so the C encoders must reject it explicitly.
+
+    Without an explicit guard the "d" format unit coerces True/False to
+    1.0/0.0 before any validation runs, so a direct extension call would encode
+    a boolean as a coordinate while the package-root wrappers raise.
+    """
+    from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
+
+    for c_func in (c_encode, c_encode_strictly):
+        for latitude, longitude in (
+            (True, 0.0),
+            (False, 0.0),
+            (0.0, True),
+            (0.0, False),
+            (True, True),
+        ):
+            with pytest.raises(ValueError, match="latitude and longitude must be numbers, not booleans"):
+                c_func(latitude, longitude, 5)
+
+
+def test_c_encode_rejects_boolean_precision():
+    from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
+
+    for c_func in (c_encode, c_encode_strictly):
+        for bad_precision in (True, False):
+            with pytest.raises(ValueError, match="precision must be an integer, not a boolean"):
+                c_func(0.0, 0.0, bad_precision)
+            with pytest.raises(ValueError, match="precision must be an integer, not a boolean"):
+                c_func(0.0, 0.0, precision=bad_precision)
+
+
+def test_c_encode_accepts_ordinary_numeric_arguments():
+    """The boolean guards must not disturb plain int/float arguments."""
+    from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
+
+    for c_func in (c_encode, c_encode_strictly):
+        assert c_func(42.6, -5.6, 5) == "ezs42"
+        assert c_func(42.6, -5.6) == "ezs42e44yx96"
+        assert c_func(42, -5, 5) == "ezkqy"
+        assert c_func(0.0, 0.0, 1) == "s"
+        assert c_func(latitude=42.6, longitude=-5.6, precision=12) == "ezs42e44yx96"
+
+
 def test_c_encode_preserves_finite_coordinate_normalization():
     from pygeohash.cgeohash.geohash_module import encode as c_encode, encode_strictly as c_encode_strictly
 


### PR DESCRIPTION
Closes #109

## What changed

`geohash_encode` and `geohash_encode_strictly` in `pygeohash/cgeohash/geohash_module.c` parsed their arguments with `PyArg_ParseTupleAndKeywords(..., "dd|i", ...)`. Because `bool` is a subclass of `int`, those format units coerced `True`/`False` to `1.0`/`0.0` (and `precision=True` to precision 1) before the existing finite/range checks could distinguish them — so `geohash_module.encode(True, 0.0, 5)` returned `s00j8` while the package-root `pgh.encode` raised `ValueError`.

Both entry points now parse through two small converter functions:

- `convert_coordinate` rejects `bool` with `ValueError("latitude and longitude must be numbers, not booleans")`, then converts with `PyFloat_AsDouble`.
- `convert_precision` rejects `bool` with `ValueError("precision must be an integer, not a boolean")`, then converts through `PyNumber_Index` + `PyLong_AsLong` with the same `int`-range overflow behavior the `"i"` unit had.

Ordinary ints/floats, keyword arguments, the default precision, the existing precision bounds check (1–12) and the non-finite coordinate rejection are all unchanged. Non-numeric arguments still raise `TypeError`.

Tests were added alongside the existing direct-extension tests in `tests/test_geohash.py`: boolean coordinates, boolean precision (positional and keyword), and an explicit assertion that plain int/float arguments still produce the same geohashes.

## Verification

Environment: `uv venv --python 3.12` + `uv pip install -e ".[dev,viz]"` in the worktree; the C extension was rebuilt after each edit.

- `.venv/bin/python -m pytest` — **323 passed** (320 before, 3 new tests).
- `.venv/bin/python -m ruff format . --check` — 36 files already formatted.
- `.venv/bin/python -m ruff check .` — All checks passed.
- `.venv/bin/python -m mypy --python-version 3.12 pygeohash` — Success, no issues in 13 source files.

Mutation tests (each mutation rebuilt the extension, was confirmed present in the source, then reverted; the suite is green again afterwards):

| Mutation | Result |
|---|---|
| Remove the `bool` guard from `convert_coordinate` | `test_c_encode_rejects_boolean_coordinates` fails |
| Remove the `bool` guard from `convert_precision` | `test_c_encode_rejects_boolean_precision` fails |
| Over-broad fix — reject every `int` coordinate (`PyLong_Check` instead of `PyBool_Check`) | integer-coordinate assertions fail |

The two guards are independent halves: reverting one leaves the other's test green, so each is pinned by its own test. The third mutation is what pins the contract that ordinary integers keep working.

Manual check against the issue's reported values, for both `encode` and `encode_strictly`:

```
encode(True, 0.0, 5)  -> ValueError: latitude and longitude must be numbers, not booleans
encode(0.0, False, 5) -> ValueError: latitude and longitude must be numbers, not booleans
encode(0.0, 0.0, True) -> ValueError: precision must be an integer, not a boolean
encode(42.6, -5.6, 5) -> 'ezs42'      encode(42, -5, 5) -> 'ezkqy'
encode(0.0, 0.0, 13)  -> ValueError: precision must be between 1 and 12
encode(inf, 0.0)      -> ValueError: latitude and longitude must be finite
```