### PR TITLE
fix: validate empty visualization collections

### DIFF
--- a/pygeohash/viz.py
+++ b/pygeohash/viz.py
@@ -225,11 +225,20 @@ def plot_geohashes(
     Returns:
         Tuple: (fig, ax) - The matplotlib figure and axis objects
 
+    Raises:
+        ValueError: If ``geohashes`` is empty, or if ``colors`` is an empty list.
+
     Examples:
         >>> import pygeohash as pgh
         >>> from pygeohash.viz import plot_geohashes
         >>> fig, ax = plot_geohashes(["9q8yyk", "9q8yym", "9q8yyj"])
     """
+    if not geohashes:
+        raise ValueError("plot_geohashes requires at least one geohash")
+
+    if not isinstance(colors, str) and not colors:
+        raise ValueError("colors must be a color name, a colormap name, or a non-empty list of colors")
+
     if not _check_viz_dependencies():
         return None, None
 
@@ -381,8 +390,19 @@ def add_geohashes(
     popups: Optional[List[str]] = None,
     tooltips: Optional[List[str]] = None,
 ) -> FoliumMapProtocol:
-    """Add multiple geohashes to the map."""
+    """Add multiple geohashes to the map.
+
+    Raises:
+        ValueError: If ``geohashes`` is non-empty and ``colors`` or ``fill_colors``
+            is an empty list.
+    """
     n_geohashes = len(geohashes)
+
+    if n_geohashes:
+        if not isinstance(colors, str) and not colors:
+            raise ValueError("colors must be a color name or a non-empty list of colors")
+        if fill_colors is not None and not fill_colors:
+            raise ValueError("fill_colors must be None or a non-empty list of colors")
 
     # Set up colors
     if isinstance(colors, str):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -273,5 +273,67 @@ def test_add_geohash_grid_rejects_explicit_invalid_bbox(bbox):
         geohash_map.add_geohash_grid(precision=2, bbox=bbox)
 
 
+def test_plot_geohashes_rejects_empty_collection():
+    """An empty geohash collection is rejected before matplotlib sees infinite axis limits."""
+    pytest.importorskip("matplotlib")
+    from pygeohash.viz import plot_geohashes
+
+    with pytest.raises(ValueError, match="at least one geohash"):
+        plot_geohashes([])
+
+
+def test_plot_geohashes_rejects_empty_colors():
+    """An empty color list is rejected instead of dividing by zero while cycling."""
+    pytest.importorskip("matplotlib")
+    from pygeohash.viz import plot_geohashes
+
+    with pytest.raises(ValueError, match="non-empty list of colors"):
+        plot_geohashes(["9q8yyk"], colors=[])
+
+
+def test_plot_geohashes_cycles_short_color_list():
+    """A short non-empty color list still cycles across a longer geohash list."""
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    from matplotlib.patches import Rectangle
+
+    from pygeohash.viz import plot_geohashes
+
+    fig, ax = plot_geohashes(["9q8yyk", "9q8yym", "9q8yyj"], colors=["red", "blue"])
+    try:
+        patches = [child for child in ax.get_children() if isinstance(child, Rectangle) and child.get_label()]
+        assert [patch.get_edgecolor() for patch in patches] == [
+            matplotlib.colors.to_rgba("red", 0.5),
+            matplotlib.colors.to_rgba("blue", 0.5),
+            matplotlib.colors.to_rgba("red", 0.5),
+        ]
+    finally:
+        matplotlib.pyplot.close(fig)
+
+
+@pytest.mark.parametrize("kwargs", [{"colors": []}, {"fill_colors": []}])
+def test_add_geohashes_rejects_empty_style_lists(kwargs):
+    """Empty color/fill-color lists are rejected instead of dividing by zero while cycling."""
+    pytest.importorskip("folium")
+    from pygeohash.viz import folium_map
+
+    geohash_map = folium_map(center=(0.0, 0.0), zoom_start=3)
+
+    with pytest.raises(ValueError, match="non-empty list of colors"):
+        geohash_map.add_geohashes(["9q8yyk"], **kwargs)
+
+
+def test_add_geohashes_cycles_short_color_list():
+    """A short non-empty color list still cycles across a longer geohash list."""
+    folium = pytest.importorskip("folium")
+    from pygeohash.viz import folium_map
+
+    geohash_map = folium_map(center=(0.0, 0.0), zoom_start=3)
+    geohash_map.add_geohashes(["9q8yyk", "9q8yym", "9q8yyj"], colors=["red", "blue"])
+
+    rectangles = [child for child in geohash_map._children.values() if isinstance(child, folium.Rectangle)]
+    assert [rectangle.options["color"] for rectangle in rectangles] == ["red", "blue", "red"]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #107

## What changed

`pygeohash/viz.py` now validates its two multi-geohash entry points instead of letting empty collections fall through to a low-level exception:

- `plot_geohashes` raises `ValueError("plot_geohashes requires at least one geohash")` for an empty collection, before the infinite initial bounds can reach `set_xlim`/`set_ylim`.
- `plot_geohashes` raises `ValueError` for an empty `colors` list (a `str` colormap/color name is still accepted as before).
- `add_geohashes` raises `ValueError` for an empty `colors` or `fill_colors` list when the geohash list is non-empty — the two branches that previously divided by `len(...)` while cycling.

Behavior for non-empty inputs is unchanged: short non-empty style lists still cycle, and short label/popup/tooltip lists are still padded. The `colors`/`fill_colors` checks in `add_geohashes` are gated on a non-empty geohash list, so `add_geohash_grid`'s internal call is unaffected.

Both docstrings gained a `Raises:` section; no new `>>>` examples were added, so the doctest count gate is untouched.

## Verification

Reproduced first against a real `[dev,viz]` install (matplotlib 3.11.1, Folium 0.20.0) — all four cases failed as described in the issue:

```
empty geohashes -> ValueError Axis limits cannot be NaN or Inf
empty colors    -> ZeroDivisionError integer division or modulo by zero
map colors      -> ZeroDivisionError integer division or modulo by zero
map fill_colors -> ZeroDivisionError integer division or modulo by zero
short cycle     -> OK
```

Gates run (Python 3.12, `-e ".[dev,viz]"`):

- `python -m pytest` — **326 passed** (320 on `master` at 1e20e12; +6 new)
- `python -m ruff format . --check` — 36 files already formatted
- `python -m ruff check .` — All checks passed
- `python -m mypy --python-version 3.12 pygeohash` — Success, 13 source files
- `sphinx -W --keep-going -b html source build/html` — build succeeded (run because public docstrings changed)

**Mutation testing.** The four guards are independent halves, so each was reverted separately with the rest of the fix committed and `__pycache__` cleared between runs. Each reversion reddened exactly one test:

| reverted guard | failing test |
|---|---|
| `plot_geohashes` empty-geohashes | `test_plot_geohashes_rejects_empty_collection` |
| `plot_geohashes` empty-`colors` | `test_plot_geohashes_rejects_empty_colors` |
| `add_geohashes` empty-`colors` | `test_add_geohashes_rejects_empty_style_lists[kwargs0]` |
| `add_geohashes` empty-`fill_colors` | `test_add_geohashes_rejects_empty_style_lists[kwargs1]` |

After restoring, `tests/test_viz.py` is 18 passed and `git status --porcelain` is empty.

To be explicit about which tests carry behavior: the four cases above are the guards. The two cycling tests (`test_plot_geohashes_cycles_short_color_list`, `test_add_geohashes_cycles_short_color_list`) pass on the unfixed code too — they assert the exact per-rectangle color sequence `red, blue, red` for a 2-color/3-geohash input and exist to pin that this PR did **not** change the cycling path, which is the issue's fourth acceptance item. They document rather than guard.

Tests use the real matplotlib/Folium stack (`pytest.importorskip`, asserting on real `Rectangle` patches and Folium children) rather than the mocked axes in the existing `TestViz` class, since mocks are exactly what hid the infinite-axis-limit failure.