### PR TITLE
Validate the geohash and direction arguments in get_adjacent()

### DIFF
--- a/pygeohash/neighbor.py
+++ b/pygeohash/neighbor.py
@@ -6,10 +6,10 @@ in different directions (right, left, top, bottom).
 
 from __future__ import annotations
 
-from typing import Dict, Final, Literal
+from typing import Dict, Final, Literal, Tuple
 
 from pygeohash.geohash import __base32
-from pygeohash.types import Direction
+from pygeohash.types import Direction, is_valid_geohash
 from pygeohash.logging import get_logger
 
 logger = get_logger(__name__)
@@ -54,6 +54,8 @@ BORDERS: Final[Dict[Direction, Dict[Literal["even", "odd"], str]]] = {
     },
 }
 
+DIRECTIONS: Final[Tuple[Direction, ...]] = ("right", "left", "top", "bottom")
+
 
 def get_adjacent(geohash: str, direction: Direction) -> str:
     """Calculate the adjacent geohash in the specified direction.
@@ -69,8 +71,11 @@ def get_adjacent(geohash: str, direction: Direction) -> str:
         other side of the grid.
 
     Raises:
-        ValueError: If the geohash is empty, or if the requested neighbor would lie beyond
-        the north or south pole ("top" of the top row, "bottom" of the bottom row).
+        ValueError: If the geohash is empty; if it is not a canonical geohash (1-12
+        characters drawn from the geohash base32 alphabet, case-insensitive); if the
+        direction is not one of "right", "left", "top" or "bottom"; or if the requested
+        neighbor would lie beyond the north or south pole ("top" of the top row,
+        "bottom" of the bottom row).
 
     Example:
         >>> get_adjacent("u4pruyd", "top")
@@ -81,6 +86,17 @@ def get_adjacent(geohash: str, direction: Direction) -> str:
     if len(geohash) == 0:
         logger.error("Cannot find adjacent geohash: input geohash length is 0")
         raise ValueError("The geohash length cannot be 0. Possible when close to poles")
+
+    if not is_valid_geohash(geohash):
+        logger.error("Cannot find adjacent geohash: %r is not a valid geohash", geohash)
+        raise ValueError(
+            f"Invalid geohash: {geohash!r}. A geohash must be 1 to 12 characters "
+            "from the base32 alphabet '0123456789bcdefghjkmnpqrstuvwxyz'"
+        )
+
+    if direction not in DIRECTIONS:
+        logger.error("Cannot find adjacent geohash: %r is not a valid direction", direction)
+        raise ValueError(f"Invalid direction: {direction!r}. Must be one of 'right', 'left', 'top', 'bottom'")
 
     source_hash = geohash.lower()
     last_char = source_hash[-1]

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -54,6 +54,43 @@ def test_zero_length_geohash():
         pgh.get_adjacent("", "top")
 
 
+INVALID_GEOHASHES = [
+    "a4pruyd",  # 'a' is not in the geohash alphabet
+    "u4pr!yd",  # punctuation mid-string
+    "u4pru!",  # invalid last character
+    "u4pruydqqvjuu4pr",  # 16 characters, over the 12-character maximum
+    "u4pruyd ",  # trailing whitespace
+    "u4pr yd",  # embedded space
+]
+
+
+@pytest.mark.parametrize("geohash", INVALID_GEOHASHES)
+@pytest.mark.parametrize("direction", ["right", "left", "top", "bottom"])
+def test_invalid_geohash_raises(geohash, direction):
+    with pytest.raises(ValueError, match="Invalid geohash"):
+        pgh.get_adjacent(geohash, direction)
+
+
+def test_invalid_last_character_message_is_geohash_specific():
+    """An invalid final character must not leak str.index's 'substring not found'."""
+    with pytest.raises(ValueError, match=r"^Invalid geohash: 'u4pru!'\."):
+        pgh.get_adjacent("u4pru!", "top")
+
+
+@pytest.mark.parametrize("direction", ["up", "down", "north", "TOP", "", "Right"])
+def test_invalid_direction_raises_value_error(direction):
+    with pytest.raises(ValueError, match="Must be one of 'right', 'left', 'top', 'bottom'"):
+        pgh.get_adjacent("u4pruyd", direction)
+
+
+def test_uppercase_geohash_is_still_accepted():
+    assert pgh.get_adjacent("U4PRUYD", "top") == "u4pruyf"
+
+
+def test_maximum_precision_geohash_is_accepted():
+    assert pgh.get_adjacent("u4pruydqqvju", "top") == "u4pruydqqvjv"
+
+
 ANTIMERIDIAN_PAIRS = [
     # (western-edge geohash, eastern-edge geohash) -- each is the other's east/west neighbor
     ("8", "x"),


### PR DESCRIPTION
Closes #122

`get_adjacent()` was the only public geohash-consuming function with no input validation. It looked up **only the last character** in the neighbor table and carried the rest of the string through verbatim, so invalid input silently produced strings that every other function in the package rejects:

```
>>> pgh.get_adjacent("a4pruyd", "top")          # 'a' is not in the geohash alphabet
'a4pruyf'                                       # ... which pgh.decode() then refuses
>>> pgh.get_adjacent("u4pruydqqvjuu4pr", "top") # 16 characters in, 16 characters out
'u4pruydqqvjuu4r2'
```

## Changes

`pygeohash/neighbor.py`:

1. After the existing zero-length check, `get_adjacent` rejects any input that is not a canonical geohash by delegating to `pygeohash.types.is_valid_geohash` (case-insensitive, 1-12 characters, alphabet-checked), raising `ValueError` naming the offending value. This also replaces the bare `ValueError: substring not found` that `neighbor_str.index(last_char)` raised for an invalid *last* character.
2. An unknown direction now raises `ValueError` listing the four valid values instead of `KeyError: 'up'`. The valid set is a new module-level `DIRECTIONS` tuple.
3. The `Raises:` section of the `get_adjacent` docstring states both rules.

The zero-length check stays **first**, so `test_zero_length_geohash`'s anchored `"^The geohash length cannot be 0. Possible when close to poles$"` regex is unaffected. No new imports beyond a symbol from a module `neighbor.py` already imported, so no new dependency cycle.

`tests/test_neighbor.py` gains 33 cases in the file's existing style (module-level case list plus `@pytest.mark.parametrize`, alongside the antimeridian pairs): six invalid geohashes x four directions, a message-specific assertion for the invalid-last-character path, six invalid directions, and two preserved-behavior assertions (uppercase input, 12-character input).

This is additive input validation on one public function. The behavior change is that calls which previously returned an unusable string now raise; every input `decode`/`is_valid_geohash` accept is unaffected.

## Verification

All run with `.[dev,viz]` installed in the worktree venv:

| Gate | Result |
| --- | --- |
| `.venv/bin/python -m pytest` | **362 passed** (329 collected on master before this change) |
| `.venv/bin/python -m ruff format . --check` | 37 files already formatted |
| `.venv/bin/python -m ruff check .` | All checks passed |
| `.venv/bin/python -m mypy --python-version 3.12 pygeohash` | Success: no issues found in 13 source files |
| `cd docs && ../.venv/bin/python -m sphinx -W --keep-going -b html source /tmp/docsbuild122` | build succeeded (run because a public docstring changed) |

All 30 pre-existing `tests/test_neighbor.py` expectations pass unchanged, including the 8 hand-written hemisphere/parity/pole tests and the antimeridian parametrization.

### Acceptance checks, measured

```
>>> pgh.get_adjacent("a4pruyd", "top")
ValueError: Invalid geohash: 'a4pruyd'. A geohash must be 1 to 12 characters from the base32 alphabet '0123456789bcdefghjkmnpqrstuvwxyz'
>>> pgh.get_adjacent("u4pr!yd", "top")            # same ValueError shape
>>> pgh.get_adjacent("u4pruydqqvjuu4pr", "top")   # same ValueError shape
>>> pgh.get_adjacent("u4pru!", "top")             # geohash-specific, not "substring not found"
>>> pgh.get_adjacent("u4pruyd", "up")
ValueError: Invalid direction: 'up'. Must be one of 'right', 'left', 'top', 'bottom'
>>> pgh.get_adjacent("U4PRUYD", "top")
'u4pruyf'
```

### Mutation check

The two validations are independent halves, so each was reverted **separately** (the other left in place, confirmed by grep, with `PYTHONDONTWRITEBYTECODE=1` set so no stale bytecode was served):

| Mutation | `tests/test_neighbor.py` result |
| --- | --- |
| Delete the geohash validation only | **25 failed**, 38 passed — the 24 `test_invalid_geohash_raises` cases plus `test_invalid_last_character_message_is_geohash_specific` |
| Delete the direction validation only | **6 failed**, 57 passed — the six `test_invalid_direction_raises_value_error` cases |

The two failing sets are disjoint, so neither half is guarded by the other's tests. Restoring both returns the full suite to 362 passed.