### PR TITLE
Make the logging helpers emit records and register undoubled logger names

### DIFF
--- a/pygeohash/logging.py
+++ b/pygeohash/logging.py
@@ -22,14 +22,17 @@ def get_logger(name: Optional[str] = None) -> logging.Logger:
     """Get a logger instance for the specified name.
 
     Args:
-        name: The name of the logger to get. If None, returns the main pygeohash logger.
-            If specified, returns a child logger of the main pygeohash logger.
+        name: The name of the logger to get. If None or ``"pygeohash"``, returns the main
+            pygeohash logger. Fully qualified pygeohash names are returned as-is; other
+            names are treated as children of the main pygeohash logger.
 
     Returns:
         logging.Logger: The requested logger instance.
     """
     if name is None:
         return logger
+    if name == logger.name or name.startswith(f"{logger.name}."):
+        return logging.getLogger(name)
     return logger.getChild(name)
 
 
@@ -51,7 +54,8 @@ def add_stream_handler(
     """Add a stream handler to the pygeohash logger.
 
     Args:
-        level: The logging level for the handler. Defaults to INFO.
+        level: The logging level for the handler. Defaults to INFO. If the pygeohash
+            logger would filter records at this level, its level is lowered to match.
         format_string: The format string for log messages.
         **handler_kwargs: Additional keyword arguments to pass to StreamHandler.
     """
@@ -60,6 +64,8 @@ def add_stream_handler(
     formatter = logging.Formatter(format_string)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    if logger.getEffectiveLevel() > handler.level:
+        logger.setLevel(handler.level)
 
 
 def add_file_handler(
@@ -72,7 +78,8 @@ def add_file_handler(
 
     Args:
         filename: The name of the file to log to.
-        level: The logging level for the handler. Defaults to INFO.
+        level: The logging level for the handler. Defaults to INFO. If the pygeohash
+            logger would filter records at this level, its level is lowered to match.
         format_string: The format string for log messages.
         **handler_kwargs: Additional keyword arguments to pass to FileHandler.
     """
@@ -81,6 +88,8 @@ def add_file_handler(
     formatter = logging.Formatter(format_string)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    if logger.getEffectiveLevel() > handler.level:
+        logger.setLevel(handler.level)
 
 
 def remove_all_handlers() -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,104 @@
+import io
+import logging
+from pathlib import Path
+
+import pytest
+
+import pygeohash as pgh
+
+
+@pytest.fixture(autouse=True)
+def reset_pygeohash_logging() -> None:
+    pgh.remove_all_handlers()
+    pgh.set_log_level(logging.NOTSET)
+    yield
+    pgh.remove_all_handlers()
+    pgh.set_log_level(logging.NOTSET)
+
+
+def test_stream_handler_emits_debug_records() -> None:
+    stream = io.StringIO()
+
+    pgh.add_stream_handler(level=logging.DEBUG, stream=stream)
+    pgh.get_adjacent("u4pruyd", "top")
+
+    output = stream.getvalue()
+    assert "Finding adjacent geohash for u4pruyd in direction top" in output
+    assert "pygeohash.neighbor" in output
+    assert "pygeohash.pygeohash" not in output
+
+
+def test_stream_handler_default_emits_warning_records() -> None:
+    stream = io.StringIO()
+
+    pgh.add_stream_handler(stream=stream)
+    pgh.mean([])
+
+    assert "Empty geohash collection provided" in stream.getvalue()
+
+
+def test_file_handler_emits_records(tmp_path: Path) -> None:
+    log_file = tmp_path / "pygeohash.log"
+
+    pgh.add_file_handler(str(log_file), level=logging.DEBUG)
+    pgh.get_adjacent("u4pruyd", "top")
+
+    assert "Finding adjacent geohash for u4pruyd in direction top" in log_file.read_text()
+
+
+def test_stream_handler_does_not_configure_root_logger() -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+
+    pgh.add_stream_handler(stream=io.StringIO())
+
+    assert root_logger.handlers == original_handlers
+    assert root_logger.level == original_level
+
+
+def test_module_loggers_use_fully_qualified_names() -> None:
+    import pygeohash.bounding_box  # noqa: F401
+    import pygeohash.distances  # noqa: F401
+    import pygeohash.geohash  # noqa: F401
+    import pygeohash.neighbor  # noqa: F401
+    import pygeohash.stats  # noqa: F401
+    import pygeohash.types  # noqa: F401
+
+    names = [name for name in logging.Logger.manager.loggerDict if name.startswith("pygeohash")]
+    assert not any(name.startswith("pygeohash.pygeohash") for name in names)
+
+
+def test_module_logger_handler_receives_neighbor_records() -> None:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.DEBUG)
+    module_logger = logging.getLogger("pygeohash.neighbor")
+    original_level = module_logger.level
+    module_logger.setLevel(logging.DEBUG)
+    module_logger.addHandler(handler)
+
+    try:
+        pgh.get_adjacent("u4pruyd", "top")
+    finally:
+        module_logger.removeHandler(handler)
+        module_logger.setLevel(original_level)
+
+    assert "Finding adjacent geohash for u4pruyd in direction top" in stream.getvalue()
+
+
+def test_get_logger_preserves_bare_child_name() -> None:
+    assert pgh.get_logger("myapp").name == "pygeohash.myapp"
+
+
+def test_get_logger_returns_package_logger_for_package_name() -> None:
+    assert pgh.get_logger("pygeohash") is pgh.logger
+
+
+def test_remove_all_handlers_restores_only_null_handler() -> None:
+    pgh.add_stream_handler(stream=io.StringIO())
+
+    pgh.remove_all_handlers()
+
+    assert len(pgh.logger.handlers) == 1
+    assert isinstance(pgh.logger.handlers[0], logging.NullHandler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import io
 import logging
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -8,7 +9,7 @@ import pygeohash as pgh
 
 
 @pytest.fixture(autouse=True)
-def reset_pygeohash_logging() -> None:
+def reset_pygeohash_logging() -> Iterator[None]:
     pgh.remove_all_handlers()
     pgh.set_log_level(logging.NOTSET)
     yield
@@ -35,6 +36,21 @@ def test_stream_handler_default_emits_warning_records() -> None:
     pgh.mean([])
 
     assert "Empty geohash collection provided" in stream.getvalue()
+
+
+def test_stream_handler_default_delivers_info_records() -> None:
+    stream = io.StringIO()
+    root_logger = logging.getLogger()
+    original_root_level = root_logger.level
+    root_logger.setLevel(logging.WARNING)
+
+    try:
+        pgh.add_stream_handler(stream=stream)
+        pgh.logger.info("info level record")
+    finally:
+        root_logger.setLevel(original_root_level)
+
+    assert "info level record" in stream.getvalue()
 
 
 def test_file_handler_emits_records(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #123

## What changed

`pygeohash/logging.py` (+17/-4) and a new `tests/test_logging.py`, which previously had no test file at all (module coverage 44%, every helper body uncovered).

**1. `add_stream_handler` / `add_file_handler` now deliver records at the requested level.** Both set a level on the *handler* but left the `pygeohash` logger at `NOTSET`, so its effective level was inherited from root (`WARNING`) and every `DEBUG`/`INFO` record was dropped before any handler saw it — making the out-of-the-box `pgh.add_stream_handler()` a silent no-op. Each helper now lowers the package logger's level to the handler level, and only when the logger would otherwise filter those records:

```python
if logger.getEffectiveLevel() > handler.level:
    logger.setLevel(handler.level)
```

The root logger is not touched and `logging.basicConfig` is not called, so the module's stated library-logging contract still holds.

**2. `get_logger` no longer doubles the package prefix.** It did `logger.getChild(name)` unconditionally, while every module calls `get_logger(__name__)` with `__name__` already `pygeohash.<module>` — registering `pygeohash.pygeohash.neighbor` and friends. Records carried the doubled name, and the natural `logging.getLogger("pygeohash.neighbor")` filter controlled nothing. Already-qualified names are now returned as-is; a bare sub-name still becomes a child (`get_logger("myapp").name == "pygeohash.myapp"`), and `get_logger()` still returns the package logger.

Both docstrings document the resulting behavior. Out of scope, as the issue specified: deduplicating repeated `add_stream_handler` calls, and changing what any module logs.

## Verification

Environment: CPython 3.12.11, `-e ".[dev,viz]"`. All four gates green on the branch:

| Gate | Result |
|---|---|
| `pytest` | **339 passed** |
| `ruff format . --check` | 38 files already formatted |
| `ruff check .` | All checks passed |
| `mypy pygeohash` | Success: no issues found in 13 source files |

**Test count baseline (measured, not remembered):** 329 collected/passed on `master` at `5eceabb` with the same extras; 339 with this branch, so the new file adds 10.

### Acceptance checklist

Each item was run in a fresh interpreter with cwd outside the checkout. All eight pass:

- `add_stream_handler(level=DEBUG, stream=buf)` + `get_adjacent("u4pruyd", "top")` writes to `buf` with **no** `set_log_level` — 507 bytes, `pygeohash.neighbor - DEBUG - Finding adjacent geohash for u4pruyd in direction top`.
- Default `add_stream_handler(stream=buf)` at INFO likewise emits from a real call site (`pgh.mean([])` → `pygeohash.stats - WARNING - Empty geohash collection provided`).
- `add_file_handler(path)` writes records to `path` with no separate `set_log_level`.
- Root logger unchanged after `add_stream_handler`: `handlers=[]`, `level=30`.
- After importing every submodule, the registry holds exactly `pygeohash`, `pygeohash.{bounding_box,distances,geohash,neighbor,stats,types}` — no `pygeohash.pygeohash*` name.
- A DEBUG handler on `logging.getLogger("pygeohash.neighbor")` receives records emitted by `neighbor.py`.
- `get_logger("myapp").name == "pygeohash.myapp"`.
- `remove_all_handlers()` leaves exactly one handler, a `logging.NullHandler`.

### Mutation check

Each half reverted **separately**, `__pycache__` cleared between runs, restored and re-confirmed green (339) afterwards:

| Mutation | Caught by |
|---|---|
| Revert **both** logger-level lowerings | 3 failed — `test_stream_handler_emits_debug_records`, `test_stream_handler_default_delivers_info_records`, `test_file_handler_emits_records` |
| Revert **only** the `add_stream_handler` lowering | 2 failed (the two stream tests) |
| Revert **only** the `add_file_handler` lowering | 1 failed (`test_file_handler_emits_records`) |
| Revert the `get_logger` naming fix | 4 failed — `test_stream_handler_emits_debug_records`, `test_module_loggers_use_fully_qualified_names`, `test_module_logger_handler_receives_neighbor_records`, `test_get_logger_returns_package_logger_for_package_name` |

The two stream/file lowerings are independent halves and are guarded independently, so neither can be dropped silently.

**Which test carries the behavior, and which documents it:** the package has no `logger.info` call site — it logs only at DEBUG and WARNING. So `test_stream_handler_default_emits_warning_records` passes on the *unfixed* code too (a WARNING record already clears the inherited effective level); it documents that a real call site reaches the handler rather than guarding the fix. The genuine guard for the documented INFO default is `test_stream_handler_default_delivers_info_records`, which pins the root logger to WARNING for its duration so the assertion does not depend on pytest's ambient `log_cli_level = "INFO"`, then asserts an INFO record is actually delivered.

### State hygiene

`logging` state is process-global and this repo's pytest config sets `log_cli = true` / `log_cli_level = "INFO"`, so a leaked level would make every later test noisy. An autouse fixture calls `remove_all_handlers()` and restores the package logger to `NOTSET` before and after each test; the one test that touches the root level restores it in a `finally`. The full suite is green in either order and `git status --porcelain` is empty after a complete run.