### PR TITLE
docs: document conda-forge installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/pygeohash.svg)](https://badge.fury.io/py/pygeohash)
 [![Python Versions](https://img.shields.io/pypi/pyversions/pygeohash.svg)](https://pypi.org/project/pygeohash/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/pygeohash.svg)](https://anaconda.org/conda-forge/pygeohash)
 
 A simple, lightweight, and dependency-free Python library for working with geohashes.
 
@@ -27,6 +28,9 @@ It was originally based on Leonard Norrgård's [geohash](https://github.com/vins
 ```bash
 # Basic installation
 pip install pygeohash
+
+# Or from conda-forge
+conda install -c conda-forge pygeohash
 
 # With visualization support
 pip install pygeohash[viz]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,12 @@ Installation:
 
     pip install pygeohash
 
+or, with conda:
+
+.. code-block:: bash
+
+    conda install -c conda-forge pygeohash
+
 Basic usage:
 
 .. code-block:: python

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -12,6 +12,12 @@ PyGeoHash can be installed from PyPI using pip:
 
     pip install pygeohash
 
+or from conda-forge:
+
+.. code-block:: bash
+
+    conda install -c conda-forge pygeohash
+
 Basic Operations
 ----------------
 


### PR DESCRIPTION
Documents conda-forge as an installation option: a version badge in the README, plus `conda install -c conda-forge pygeohash` in the README installation section, the docs landing page, and the usage guide.

Addresses the discoverability half of #128.

## Draft until conda-forge actually has 3.3.2

**Do not merge yet.** conda-forge currently serves pygeohash 1.2.0 from 2019, so merging this today would point users at a four-year-old package with a completely different API — worse than saying nothing. The badge would also render `1.2.0`, which looks like a stale release rather than a stale feedstock.

Merge this once conda-forge/pygeohash-feedstock#11 has landed and 3.3.2 is visible on anaconda.org across the build matrix.

## Feedstock work in flight

- conda-forge/pygeohash-feedstock#11 — 3.3.2, drops `noarch: python` for the C extension, corrects the license from AGPL-3.0 to MIT, and adds me as a recipe maintainer. Merge first.
- conda-forge/pygeohash-feedstock#10 — enables bot automerge so future releases sync automatically. Merge last.

<!-- Generated with [Claude Code](https://claude.com/claude-code) -->
