### PR TITLE
Return the C decoder's named tuples directly from decode()/decode_exactly()

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,24 +164,24 @@ This project is licensed under the MIT license. See the LICENSE file for details
 
 Median time per call in nanoseconds — lower is better. Measured on an Apple M4
 (macOS, CPython 3.12.11) with the suite in `tests/test_benchmark_comparison.py`,
-run three times.
+run seven times.
 
 | Library | Implementation | encode | decode | bbox |
 |---|---|---|---|---|
-| geohashr | Rust extension | 125 | 80 | 104 |
-| pygeohash-fast | Rust extension | 166 | 167 | — |
+| geohashr | Rust extension | 86 | 81 | 104 |
+| pygeohash-fast | Rust extension | 125 | 167 | — |
+| **pygeohash** | **C extension** | **204** | **250** | **667** |
 | python-geohash | C++ extension | 208 | 250 | 250 |
-| **pygeohash** | **C extension** | **250** | **333** | **709** |
-| libgeohash | pure Python | 2,709 | 2,625 | 2,750 |
-| geohash-tools | pure Python | 3,792 | 3,375 | — |
-| geolib | pure Python | 10,584 | 58,208 | 43,292 |
+| libgeohash | pure Python | 2,750 | 2,625 | 2,750 |
+| geohash-tools | pure Python | 3,833 | 3,375 | — |
+| geolib | pure Python | 10,584 | 57,708 | 43,875 |
 
-PyGeoHash is 3.9x to 10.8x faster than the quickest pure-Python library, depending
-on the operation, and lands within 1.2x of `python-geohash` on `encode` (1.3x on
-`decode`, 2.8x on bounding boxes) — the C++ extension it is commonly swapped in
-for when a build toolchain is not available. The two Rust extensions are faster
-than PyGeoHash on everything measured here, and the two fastest `encode` entries
-are within measurement noise of each other.
+PyGeoHash is 4.1x to 13.5x faster than the quickest pure-Python library, depending
+on the operation. Against `python-geohash` — the C++ extension it is commonly
+swapped in for when a build toolchain is not available — the repeated runs do not
+separate the two on `encode` or on `decode`; PyGeoHash takes 2.7x its time on
+bounding boxes. The two Rust extensions are faster than PyGeoHash on everything
+measured here, and they are within measurement noise of each other on `encode`.
 
 These are medians from one machine and one set of runs. The full tables, the
 exact library versions, the caveats and the command to regenerate everything are

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -21,7 +21,7 @@ others are excluded from the suite entirely: ``geohash-hilbert`` computes a
 Hilbert-curve variant rather than a standard geohash, and ``mzgeohash`` takes no
 precision parameter, so equal work cannot be guaranteed.
 
-The whole suite was run 3 times. Each library's headline figure is the
+The whole suite was run 7 times. Each library's headline figure is the
 median of its per-run medians, and the range column gives the lowest and highest
 median it produced, so the run-to-run movement behind every number is visible.
 Ops/sec is derived from the headline median, and the final column is each
@@ -39,59 +39,59 @@ Encode ``(42.6, -5.6)`` to a precision-9 geohash.
    * - Library
      - Implementation
      - Median (ns)
-     - Range over 3 runs (ns)
+     - Range over 7 runs (ns)
      - Ops/sec
      - vs pygeohash
    * - geohashr
      - Rust extension
-     - 125
-     - 84 - 166
-     - 8,005,531
-     - 0.50x
+     - 86
+     - 84 - 125
+     - 11,688,548
+     - 0.42x
    * - pygeohash-fast
      - Rust extension
-     - 166
-     - 125 - 166
-     - 6,023,797
-     - 0.66x
+     - 125
+     - 125 - 125
+     - 7,999,939
+     - 0.61x
+   * - **pygeohash**
+     - C extension
+     - 204
+     - 202 - 206
+     - 4,898,352
+     - 1.00x
    * - python-geohash
      - C++ extension
      - 208
-     - 208 - 209
-     - 4,806,902
-     - 0.83x
-   * - **pygeohash**
-     - C extension
-     - 250
-     - 250 - 584
-     - 3,999,038
-     - 1.00x
+     - 165 - 208
+     - 4,807,575
+     - 1.02x
    * - libgeohash
      - pure Python
-     - 2,709
-     - 2,709 - 2,709
-     - 369,142
-     - 10.83x
+     - 2,750
+     - 2,709 - 2,750
+     - 363,637
+     - 13.47x
    * - geohash-tools
      - pure Python
-     - 3,792
-     - 3,792 - 3,833
-     - 263,713
-     - 15.16x
+     - 3,833
+     - 3,792 - 3,834
+     - 260,892
+     - 18.78x
    * - geolib
      - pure Python
      - 10,584
-     - 10,584 - 10,625
+     - 10,542 - 10,834
      - 94,482
-     - 42.33x
+     - 51.84x
 
-On this machine pygeohash takes 1.20x the median time of ``python-geohash`` and is 10.8x
-faster than ``libgeohash``, the quickest pure-Python entry. ``geohashr``,
-``pygeohash-fast`` are faster still.
+On this machine pygeohash is 1.02x faster than ``python-geohash`` and is 13.5x faster
+than ``libgeohash``, the quickest pure-Python entry. ``geohashr``, ``pygeohash-fast``
+are faster still.
 
-The repeated runs did not separate ``geohashr`` and ``pygeohash-fast``. Their ranges of
-medians overlap, so their relative order in the table is within measurement noise and
-swaps between runs: read them as tied.
+The repeated runs did not separate ``geohashr`` and ``pygeohash-fast``; ``pygeohash``
+and ``python-geohash``. Their ranges of medians overlap, so their relative order in the
+table is within measurement noise and swaps between runs: read them as tied.
 
 Decode
 ------
@@ -105,55 +105,59 @@ Decode ``ezs42e44y`` back to coordinates.
    * - Library
      - Implementation
      - Median (ns)
-     - Range over 3 runs (ns)
+     - Range over 7 runs (ns)
      - Ops/sec
      - vs pygeohash
    * - geohashr
      - Rust extension
-     - 80
-     - 80 - 81
-     - 12,435,484
-     - 0.24x
+     - 81
+     - 81 - 81
+     - 12,339,577
+     - 0.32x
    * - pygeohash-fast
      - Rust extension
      - 167
-     - 166 - 167
-     - 5,990,191
-     - 0.50x
+     - 167 - 167
+     - 5,988,104
+     - 0.67x
+   * - **pygeohash**
+     - C extension
+     - 250
+     - 250 - 542
+     - 3,999,970
+     - 1.00x
    * - python-geohash
      - C++ extension
      - 250
      - 250 - 250
-     - 4,000,901
-     - 0.75x
-   * - **pygeohash**
-     - C extension
-     - 333
-     - 333 - 334
-     - 3,002,424
+     - 3,999,970
      - 1.00x
    * - libgeohash
      - pure Python
      - 2,625
-     - 2,625 - 2,667
-     - 380,962
-     - 7.88x
+     - 2,625 - 2,666
+     - 380,954
+     - 10.50x
    * - geohash-tools
      - pure Python
      - 3,375
-     - 3,334 - 3,375
+     - 3,375 - 3,417
      - 296,297
-     - 10.13x
+     - 13.50x
    * - geolib
      - pure Python
-     - 58,208
-     - 56,916 - 59,313
-     - 17,180
-     - 174.77x
+     - 57,708
+     - 57,458 - 62,541
+     - 17,329
+     - 230.83x
 
-On this machine pygeohash takes 1.33x the median time of ``python-geohash`` and is 7.9x
-faster than ``libgeohash``, the quickest pure-Python entry. ``geohashr``,
-``pygeohash-fast`` are faster still.
+On this machine pygeohash is 1.00x faster than ``python-geohash`` and is 10.5x faster
+than ``libgeohash``, the quickest pure-Python entry. ``geohashr``, ``pygeohash-fast``
+are faster still.
+
+The repeated runs did not separate ``pygeohash`` and ``python-geohash``. Their ranges of
+medians overlap, so their relative order in the table is within measurement noise and
+swaps between runs: read them as tied.
 
 Bounding box
 ------------
@@ -167,41 +171,41 @@ Look up the bounding box of the ``ezs42e44y`` cell.
    * - Library
      - Implementation
      - Median (ns)
-     - Range over 3 runs (ns)
+     - Range over 7 runs (ns)
      - Ops/sec
      - vs pygeohash
    * - geohashr
      - Rust extension
      - 104
-     - 104 - 104
-     - 9,619,080
-     - 0.15x
+     - 104 - 105
+     - 9,580,832
+     - 0.16x
    * - python-geohash
      - C++ extension
      - 250
      - 250 - 291
-     - 3,999,038
-     - 0.35x
+     - 3,999,970
+     - 0.37x
    * - **pygeohash**
      - C extension
-     - 709
-     - 709 - 750
-     - 1,410,498
+     - 667
+     - 666 - 667
+     - 1,499,312
      - 1.00x
    * - libgeohash
      - pure Python
      - 2,750
-     - 2,750 - 2,750
-     - 363,626
-     - 3.88x
+     - 2,750 - 2,792
+     - 363,634
+     - 4.12x
    * - geolib
      - pure Python
-     - 43,292
-     - 42,959 - 44,000
-     - 23,099
-     - 61.06x
+     - 43,875
+     - 43,041 - 44,208
+     - 22,792
+     - 65.78x
 
-On this machine pygeohash takes 2.84x the median time of ``python-geohash`` and is 3.9x
+On this machine pygeohash takes 2.67x the median time of ``python-geohash`` and is 4.1x
 faster than ``libgeohash``, the quickest pure-Python entry. ``geohashr`` is faster
 still.
 
@@ -212,11 +216,11 @@ These figures come from repeated runs on one machine. They are not an average
 across hardware, and they should be read as an ordering rather than as
 absolute throughput you can expect elsewhere.
 
-* **Date of run**: 2026-08-14 (3 repeats of the suite)
+* **Date of run**: 2026-08-31 (7 repeats of the suite)
 * **Machine**: Apple M4 (arm64, 10 cores)
 * **Operating system**: Darwin 25.2.0
 * **Python**: CPython 3.12.11
-* **pytest-benchmark**: 5.2.3
+* **pytest-benchmark**: 5.3.0
 
 Installed versions of every library measured:
 
@@ -224,7 +228,7 @@ Installed versions of every library measured:
 * ``geohashr`` 1.6.0
 * ``geolib`` 1.0.7
 * ``libgeohash`` 0.1.1
-* ``pygeohash`` 3.4.0
+* ``pygeohash`` 3.3.2
 * ``pygeohash-fast`` 0.3.0
 * ``python-geohash`` 0.9.2
 

--- a/pygeohash/geohash.py
+++ b/pygeohash/geohash.py
@@ -153,7 +153,7 @@ def decode(geohash: str) -> LatLong:
     # The C extension raises ValueError("Invalid character in geohash") for any
     # non-base32 character, so we let it do the per-character validation instead
     # of paying for a Python-level scan on every call.
-    return LatLong(*c_decode(geohash.lower()))
+    return c_decode(geohash.lower())
 
 
 def decode_exactly(geohash: str) -> ExactLatLong:
@@ -183,7 +183,7 @@ def decode_exactly(geohash: str) -> ExactLatLong:
         raise ValueError(f"Geohash must be at most {MAX_PRECISION} characters long.")
 
     # See decode(): the C extension validates characters and raises on its own.
-    return ExactLatLong(*c_decode_exactly(geohash.lower()))
+    return c_decode_exactly(geohash.lower())
 
 
 __all__ = [

--- a/tests/test_geohash.py
+++ b/tests/test_geohash.py
@@ -269,15 +269,23 @@ def test_decode_non_ascii():
 
 
 def test_decode_return_types():
-    """decode/decode_exactly return the documented named tuples with named fields."""
+    """decode/decode_exactly return the documented named tuples with named fields.
+
+    The wrappers hand back whatever the C extension constructed, so the exact type
+    is pinned here rather than only ``isinstance``.
+    """
     from pygeohash.geohash_types import ExactLatLong, LatLong
 
     latlong = pgh.decode("ezs42")
-    assert isinstance(latlong, LatLong)
+    assert type(latlong) is LatLong
     assert latlong == (latlong.latitude, latlong.longitude)
+    assert latlong.latitude == pytest.approx(42.60498046875)
+    assert latlong.longitude == pytest.approx(-5.60302734375)
 
     exact = pgh.decode_exactly("ezs42")
-    assert isinstance(exact, ExactLatLong)
+    assert type(exact) is ExactLatLong
+    assert exact.latitude == pytest.approx(42.60498046875)
+    assert exact.longitude == pytest.approx(-5.60302734375)
     assert exact.latitude_error > 0 and exact.longitude_error > 0
 
 


### PR DESCRIPTION
Closes #137

The C extension already constructs `LatLong` / `ExactLatLong` (it caches both classes, and `geohash_module.pyi` declares exactly that since #135), so `LatLong(*c_decode(...))` in the Python wrapper paid for a tuple unpack plus a full named-tuple construction on every decode to produce a value it already had.

## What changed

- `pygeohash/geohash.py`: `decode()` returns `c_decode(geohash.lower())` and `decode_exactly()` returns `c_decode_exactly(geohash.lower())`. Every validation branch and its exact message is unchanged (`Geohash must be a string...`, `Geohash cannot be empty.`, `Geohash must be at most 12 characters long.`), and `.lower()` stays — the C decoder still rejects uppercase.
- `tests/test_geohash.py::test_decode_return_types`: strengthened in place from `isinstance` to `type(...) is LatLong` / `is ExactLatLong`, plus named-field access and values for both functions (`.latitude`, `.longitude`, `.latitude_error`, `.longitude_error`). This pins the C-side contract the change now makes load-bearing; `tests/typing/native_decode.py` is the static half.
- `docs/source/benchmarks.rst`: regenerated with `scripts/run_comparison_benchmark.py --repeats 7` (the committed page was 3 repeats).
- `README.md`: its hand-maintained copy of the cross-library table refreshed from the same run. The script prints that table but does not rewrite the README, so it goes stale silently; `decode` was 333 there and `bbox` 709. The comparative prose beneath it changed too — pygeohash and `python-geohash` no longer separate on `encode` or `decode` over 7 runs.

`LatLong` / `ExactLatLong` stay imported in `geohash.py` — `from __future__ import annotations` makes the return annotations strings, so the remaining runtime use is the `__all__` re-export.

## No value-based test can distinguish the two versions

Stated plainly because it matters for reviewing the test: the old and new forms return objects that are equal, of the same type, with the same `_fields` and the same `repr`. Reverting this change fails **no** test. The added `type(...) is ...` assertions guard the assumption the change introduces (that the C side keeps constructing the named tuples), and the mutation that kills them is wrapping the result in `tuple(...)`, not reverting the diff.

## Measurements

`timeit`, 200k-iteration inner loops, median of 3 runs of `min` over 5 repeats, both forms interleaved in one process (macOS arm64, CPython 3.12). The "before" side is the old wrapper re-declared verbatim in the same script, so the pair is measured under one machine state rather than as two separate draws:

| call | before | after | bare `c_decode` + `.lower()` |
|---|---|---|---|
| `pgh.decode("u4pruydqqvj8")` | 312.9 ns | **221.2 ns** (-29%) | 175.9 ns |
| `pgh.decode_exactly("u4pruydqqvj8")` | 335.6 ns | **236.3 ns** (-30%) | — |

Per-run spread was under 1% on every row (e.g. decode before 313.9 / 310.9 / 312.9, after 221.4 / 219.8 / 221.2).

## Verification

- `.venv/bin/python -m pytest` — **438 passed** (`[dev,viz,benchmark]` installed). `--collect-only` is 438 on `master` and 438 here — the change is behaviour-preserving and adds no test, it strengthens an existing one.
- `.venv/bin/python -m ruff format . --check` — 40 files already formatted. `ruff check .` — all checks passed. `mypy pygeohash tests/typing` — success, 14 source files. The direct return type-checks with no cast because the stub declares the named tuples.
- `sphinx -W --keep-going -b html docs/source` — build succeeded.
- `grep -n 'LatLong(\*\|ExactLatLong(\*' pygeohash/geohash.py` — no matches.

**Mutation test (the added guard is live).** With the fix committed, mutating each return to `tuple(c_decode(...))`:

| mutation | result |
|---|---|
| `decode` only | 36 failed / 402 passed |
| `decode_exactly` only | 16 failed / 422 passed |
| both | 38 failed / 400 passed |

The two failing sets are disjoint, so the halves are guarded independently. Restored, the suite is back to 438 passed and `git status` is clean.

**Benchmark page.** Regenerated with `--repeats 7`. This machine could not be brought to idle (a `StorageManagementService` scan has been running for 7h; the data volume is 92% full), so rather than assume the run was clean I checked it against the libraries this change cannot touch: every control row landed within ~1.5% of the committed page — `geolib` bbox 43,292 → 43,875, `libgeohash` encode 2,709 → 2,750, `python-geohash` decode 250 → 250, `geohashr` bbox 104 → 104.

To attribute the pygeohash movement to this diff specifically rather than to environment drift, I also A/B'd the decode and bbox groups on this checkout, alternating `master`'s `geohash.py` with this branch's, 3 rounds each:

| case | master | this branch |
|---|---|---|
| `decode[pygeohash]` | 375 ns | **205 ns** |
| `bbox[pygeohash]` | 792 ns | **667 ns** |
| `decode[geohashr]` | 81 ns | 81 ns |
| `decode[libgeohash]` | 2,625 ns | 2,625 ns |
| `decode[geolib]` | 59,083 ns | 59,083 ns |
| `bbox[libgeohash]` | 2,750 ns | 2,750 ns |

`bbox` moves because `get_bounding_box` calls `decode_exactly`. The controls are unchanged to the nanosecond.

Two provenance notes on the regenerated page, neither caused by this change: the encode row moved 250 → 204 even though encode is untouched, and the page's own provenance block now reads `pygeohash 3.3.2` where the committed page read `3.4.0` — a version no commit on `master` declares (`pyproject.toml` is 3.3.2). The committed page's encode range was `250 - 584` over 3 runs against that 3.4.0 environment; this one is `202 - 206` over 7. Worth a look separately if the discrepancy matters.

No timing gate was added to CI, per the roadmap.
