### PR TITLE
Speed up derived bounding box construction

### DIFF
--- a/pygeohash/bounding_box.py
+++ b/pygeohash/bounding_box.py
@@ -98,6 +98,11 @@ class BoundingBox(_BoundingBoxFields):
         """
         return cls(*iterable)
 
+    @classmethod
+    def _unvalidated(cls, min_lat: float, min_lon: float, max_lat: float, max_lon: float) -> "BoundingBox":
+        """Build a box from values the library itself derived, skipping validation."""
+        return tuple.__new__(cls, (min_lat, min_lon, max_lat, max_lon))
+
 
 def get_bounding_box(geohash: str) -> BoundingBox:
     """Calculate the bounding box for a geohash.
@@ -120,7 +125,7 @@ def get_bounding_box(geohash: str) -> BoundingBox:
     """
     # Get the center point and error margins
     lat, lon, lat_err, lon_err = decode_exactly(geohash)
-    return BoundingBox(lat - lat_err, lon - lon_err, lat + lat_err, lon + lon_err)
+    return BoundingBox._unvalidated(lat - lat_err, lon - lon_err, lat + lat_err, lon + lon_err)
 
 
 def is_point_in_box(lat: float, lon: float, bbox: BoundingBox) -> bool:

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,5 +1,7 @@
 """Tests for the bounding box module."""
 
+from itertools import product
+
 import pytest
 
 from pygeohash.bounding_box import (
@@ -21,6 +23,8 @@ CORNER_BOXES = [
     BoundingBox(37.875, -114.057, 38.101, -113.685),
     BoundingBox(34.365, 67.075, 34.641, 67.47),
 ]
+
+BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
 
 
 def _brute_force_geohashes(bbox: BoundingBox, precision: int, samples: int = 100) -> set:
@@ -68,6 +72,15 @@ class TestBoundingBox:
         assert isinstance(bbox, BoundingBox)
         assert bbox.min_lat < bbox.max_lat
         assert bbox.min_lon < bbox.max_lon
+
+    def test_get_bounding_box_sweep_is_ordered_and_world_bounded(self):
+        """Every precision 1-3 cell produces an ordered box within world bounds."""
+        for precision in range(1, 4):
+            for characters in product(BASE32, repeat=precision):
+                bbox = get_bounding_box("".join(characters))
+
+                assert -90.0 <= bbox.min_lat <= bbox.max_lat <= 90.0
+                assert -180.0 <= bbox.min_lon <= bbox.max_lon <= 180.0
 
     def test_bounding_box_properties(self):
         """Test the properties of the BoundingBox named tuple."""


### PR DESCRIPTION
Closes #138

## Summary

- add a private `BoundingBox._unvalidated()` constructor for coordinates derived internally from decoded geohash cells
- use it in `get_bounding_box()` while retaining the public `decode_exactly()` validation boundary
- exhaustively verify ordering and world bounds for all 33,824 precision-1 through precision-3 geohashes
- regenerate the published comparison benchmark over 7 runs and synchronize the README benchmark summary

Public `BoundingBox(...)`, `_make`, and `_replace` still use the validated construction path. Invalid `get_bounding_box()` input retains the existing exception messages.

## Performance

Measured on macOS arm64 / CPython 3.12.11 with `timeit`, taking the median of 3 runs of the minimum over 5 repeats:

- `get_bounding_box("u4pruyd")`: 698.4 ns → 447.1 ns (1.56x faster; 100,000-call inner loops)
- `geohashes_in_box(BoundingBox(57.0, 10.0, 58.0, 11.0), 5)`: 2.780 ms → 2.137 ms (1.30x faster; 100-call inner loops)

The exhaustive sweep is the behavioral guard for the unchecked path. Swapping the first two arguments to `_unvalidated()` made that test fail; after restoring the correct order, it passed again.

## Verification

- `.venv/bin/python -m pytest` — 439 passed
- `.venv/bin/python -m ruff format . --check` — 40 files already formatted
- `.venv/bin/python -m ruff check .` — all checks passed
- `.venv/bin/python -m mypy pygeohash tests/typing` — success, 14 source files
- `.venv/bin/python -m sphinx -W --keep-going -b html docs/source /tmp/pygeohash-138-docs` — build succeeded
- `.venv/bin/python scripts/run_comparison_benchmark.py --repeats 7` — 7 benchmark suites passed and regenerated `docs/source/benchmarks.rst`
- verified unchanged errors: empty geohash → `Geohash cannot be empty.`, invalid characters → `Invalid character in geohash`, and 13 characters → `Geohash must be at most 12 characters long.`